### PR TITLE
workflow: fix inaccurate test timer in benchmark

### DIFF
--- a/benchmark/client/App.vue
+++ b/benchmark/client/App.vue
@@ -72,8 +72,8 @@ const swapRows = wrap('swap', () => {
 async function bench() {
   for (let i = 0; i < 30; i++) {
     rows.value = []
-    await defer()
     await runLots()
+    await defer()
   }
 }
 

--- a/benchmark/client/profiling.ts
+++ b/benchmark/client/profiling.ts
@@ -2,6 +2,8 @@
 /* eslint-disable no-restricted-syntax */
 /* eslint-disable no-restricted-globals */
 
+import { nextTick } from '@vue/vapor'
+
 declare namespace globalThis {
   let doProfile: boolean
   let reactivity: boolean
@@ -29,13 +31,13 @@ export function wrap(
     document.body.classList.remove('done')
 
     const { doProfile } = globalThis
-    await defer()
+    await nextTick()
 
     doProfile && console.profile(id)
     const start = performance.now()
     fn(...args)
 
-    await defer()
+    await nextTick()
     let time: number
     if (globalThis.reactivity) {
       time = performance.measure(


### PR DESCRIPTION
related #269 

Change to use nextTick to record time consumption because:

1. using `requestIdleCallback` to record time is inaccurate.
2. should mainly focus on the performance loss of the JS Runtime part.