### PR TITLE
refactor(vapor): drop memo

### DIFF
--- a/packages/compiler-vapor/__tests__/transforms/__snapshots__/vFor.spec.ts.snap
+++ b/packages/compiler-vapor/__tests__/transforms/__snapshots__/vFor.spec.ts.snap
@@ -72,7 +72,7 @@ export function render(_ctx) {
       const n4 = t0()
       _renderEffect(() => _setText(n4, _ctx1[0].value+_ctx0[0].value))
       return n4
-    }, null, null, n5)
+    }, null, n5)
     _insert(n2, n5)
     return n5
   })

--- a/packages/compiler-vapor/__tests__/transforms/__snapshots__/vOnce.spec.ts.snap
+++ b/packages/compiler-vapor/__tests__/transforms/__snapshots__/vOnce.spec.ts.snap
@@ -71,7 +71,7 @@ export function render(_ctx) {
   const n0 = _createFor(() => (_ctx.list), (_ctx0) => {
     const n2 = t0()
     return n2
-  }, null, null, null, null, true)
+  }, null, null, null, true)
   return n0
 }"
 `;

--- a/packages/compiler-vapor/src/generators/for.ts
+++ b/packages/compiler-vapor/src/generators/for.ts
@@ -16,18 +16,8 @@ export function genFor(
   context: CodegenContext,
 ): CodeFragment[] {
   const { vaporHelper } = context
-  const {
-    source,
-    value,
-    key,
-    index,
-    render,
-    keyProp,
-    once,
-    id,
-    memo,
-    container,
-  } = oper
+  const { source, value, key, index, render, keyProp, once, id, container } =
+    oper
 
   let isDestructureAssignment = false
   let rawValue: string | null = null
@@ -71,7 +61,6 @@ export function genFor(
       sourceExpr,
       blockFn,
       genCallback(keyProp),
-      genCallback(memo),
       container != null && `n${container}`,
       false, // todo: hydrationNode
       once && 'true',

--- a/packages/compiler-vapor/src/ir/index.ts
+++ b/packages/compiler-vapor/src/ir/index.ts
@@ -78,7 +78,6 @@ export interface IRFor {
   value?: SimpleExpressionNode
   key?: SimpleExpressionNode
   index?: SimpleExpressionNode
-  memo?: SimpleExpressionNode
 }
 
 export interface ForIRNode extends BaseIRNode, IRFor {

--- a/packages/compiler-vapor/src/transforms/vFor.ts
+++ b/packages/compiler-vapor/src/transforms/vFor.ts
@@ -15,7 +15,7 @@ import {
   IRNodeTypes,
   type VaporDirectiveNode,
 } from '../ir'
-import { findDir, findProp, propToExpression } from '../utils'
+import { findProp, propToExpression } from '../utils'
 import { newBlock, wrapTemplate } from './utils'
 
 export const transformVFor: NodeTransform = createStructuralDirectiveTransform(
@@ -45,7 +45,6 @@ export function processFor(
   const { source, value, key, index } = parseResult
 
   const keyProp = findProp(node, 'key')
-  const memo = findDir(node, 'memo')
   const keyProperty = keyProp && propToExpression(keyProp)
   context.node = node = wrapTemplate(node, ['for'])
   context.dynamic.flags |= DynamicFlag.NON_TEMPLATE | DynamicFlag.INSERT
@@ -75,7 +74,6 @@ export function processFor(
       keyProp: keyProperty,
       render,
       once: context.inVOnce,
-      memo: memo && memo.exp,
       container,
     })
   }

--- a/packages/runtime-vapor/src/memo.ts
+++ b/packages/runtime-vapor/src/memo.ts
@@ -1,8 +1,0 @@
-export const memoStack: Array<() => any[]> = []
-
-export function withMemo<T>(memo: () => any[], callback: () => T): T {
-  memoStack.push(memo)
-  const res = callback()
-  memoStack.pop()
-  return res
-}

--- a/packages/runtime-vapor/src/renderEffect.ts
+++ b/packages/runtime-vapor/src/renderEffect.ts
@@ -12,7 +12,6 @@ import {
   queuePostFlushCb,
 } from './scheduler'
 import { VaporErrorCodes, callWithAsyncErrorHandling } from './errorHandling'
-import { memoStack } from './memo'
 
 export function renderEffect(cb: () => void): void {
   const instance = getCurrentInstance()
@@ -33,13 +32,6 @@ export function renderEffect(cb: () => void): void {
     job.id = instance.uid
   }
 
-  let memos: (() => any[])[] | undefined
-  let memoCaches: any[][]
-  if (memoStack.length) {
-    memos = Array.from(memoStack)
-    memoCaches = memos.map(memo => memo())
-  }
-
   const effect = new ReactiveEffect(() =>
     callWithAsyncErrorHandling(cb, instance, VaporErrorCodes.RENDER_FUNCTION),
   )
@@ -58,28 +50,6 @@ export function renderEffect(cb: () => void): void {
   function job() {
     if (!(effect.flags & EffectFlags.ACTIVE) || !effect.dirty) {
       return
-    }
-
-    if (memos) {
-      let dirty: boolean | undefined
-      for (let i = 0; i < memos.length; i++) {
-        const memo = memos[i]
-        const cache = memoCaches[i]
-        const value = memo()
-
-        for (let j = 0; j < Math.max(value.length, cache.length); j++) {
-          if (value[j] !== cache[j]) {
-            dirty = true
-            break
-          }
-        }
-
-        memoCaches[i] = value
-      }
-
-      if (!dirty) {
-        return
-      }
     }
 
     const reset = instance && setCurrentInstance(instance)


### PR DESCRIPTION
Closes #18

Drop `v-memo` in Vapor, since it's useless for performance.