### PR TITLE
perf(runtime-vapor): optimize `setDOMProp` on static tag + key

### DIFF
--- a/packages/compiler-vapor/__tests__/__snapshots__/compile.spec.ts.snap
+++ b/packages/compiler-vapor/__tests__/__snapshots__/compile.spec.ts.snap
@@ -186,7 +186,7 @@ export function render(_ctx) {
   _delegate(n0, "click", () => _ctx.handleClick)
   _setInheritAttrs(["id"])
   _renderEffect(() => _setText(n0, _ctx.count, "foo", _ctx.count, "foo", _ctx.count))
-  _renderEffect(() => _setDOMProp(n0, "id", _ctx.count, true))
+  _renderEffect(() => _setDOMProp(n0, "id", _ctx.count))
   return n0
 }"
 `;

--- a/packages/compiler-vapor/__tests__/__snapshots__/compile.spec.ts.snap
+++ b/packages/compiler-vapor/__tests__/__snapshots__/compile.spec.ts.snap
@@ -151,7 +151,7 @@ export function render(_ctx, $props, $emit, $attrs, $slots) {
 `;
 
 exports[`compile > directives > v-pre > should not affect siblings after it 1`] = `
-"import { resolveComponent as _resolveComponent, createComponent as _createComponent, createTextNode as _createTextNode, insert as _insert, renderEffect as _renderEffect, setAsProp as _setAsProp, template as _template } from 'vue/vapor';
+"import { resolveComponent as _resolveComponent, createComponent as _createComponent, createTextNode as _createTextNode, insert as _insert, renderEffect as _renderEffect, setDOMProp as _setDOMProp, template as _template } from 'vue/vapor';
 const t0 = _template("<div :id=\\"foo\\"><Comp></Comp>{{ bar }}</div>")
 const t1 = _template("<div></div>")
 
@@ -162,7 +162,7 @@ export function render(_ctx, $props, $emit, $attrs, $slots) {
   const n1 = _createComponent(_component_Comp)
   const n2 = _createTextNode(() => [_ctx.bar])
   _insert([n1, n2], n3)
-  _renderEffect(() => _setAsProp(n3, "id", _ctx.foo))
+  _renderEffect(() => _setDOMProp(n3, "id", _ctx.foo))
   return [n0, n3]
 }"
 `;
@@ -177,7 +177,7 @@ export function render(_ctx) {
 `;
 
 exports[`compile > dynamic root nodes and interpolation 1`] = `
-"import { delegate as _delegate, setInheritAttrs as _setInheritAttrs, renderEffect as _renderEffect, setText as _setText, setAsProp as _setAsProp, delegateEvents as _delegateEvents, template as _template } from 'vue/vapor';
+"import { delegate as _delegate, setInheritAttrs as _setInheritAttrs, renderEffect as _renderEffect, setText as _setText, setDOMProp as _setDOMProp, delegateEvents as _delegateEvents, template as _template } from 'vue/vapor';
 const t0 = _template("<button></button>")
 _delegateEvents("click")
 
@@ -186,7 +186,7 @@ export function render(_ctx) {
   _delegate(n0, "click", () => _ctx.handleClick)
   _setInheritAttrs(["id"])
   _renderEffect(() => _setText(n0, _ctx.count, "foo", _ctx.count, "foo", _ctx.count))
-  _renderEffect(() => _setAsProp(n0, "id", _ctx.count, true))
+  _renderEffect(() => _setDOMProp(n0, "id", _ctx.count, true))
   return n0
 }"
 `;

--- a/packages/compiler-vapor/__tests__/__snapshots__/compile.spec.ts.snap
+++ b/packages/compiler-vapor/__tests__/__snapshots__/compile.spec.ts.snap
@@ -151,7 +151,7 @@ export function render(_ctx, $props, $emit, $attrs, $slots) {
 `;
 
 exports[`compile > directives > v-pre > should not affect siblings after it 1`] = `
-"import { resolveComponent as _resolveComponent, createComponent as _createComponent, createTextNode as _createTextNode, insert as _insert, renderEffect as _renderEffect, setDOMProp as _setDOMProp, template as _template } from 'vue/vapor';
+"import { resolveComponent as _resolveComponent, createComponent as _createComponent, createTextNode as _createTextNode, insert as _insert, renderEffect as _renderEffect, setAsProp as _setAsProp, template as _template } from 'vue/vapor';
 const t0 = _template("<div :id=\\"foo\\"><Comp></Comp>{{ bar }}</div>")
 const t1 = _template("<div></div>")
 
@@ -162,7 +162,7 @@ export function render(_ctx, $props, $emit, $attrs, $slots) {
   const n1 = _createComponent(_component_Comp)
   const n2 = _createTextNode(() => [_ctx.bar])
   _insert([n1, n2], n3)
-  _renderEffect(() => _setDOMProp(n3, "id", _ctx.foo))
+  _renderEffect(() => _setAsProp(n3, "id", _ctx.foo))
   return [n0, n3]
 }"
 `;
@@ -177,7 +177,7 @@ export function render(_ctx) {
 `;
 
 exports[`compile > dynamic root nodes and interpolation 1`] = `
-"import { delegate as _delegate, setInheritAttrs as _setInheritAttrs, renderEffect as _renderEffect, setText as _setText, setDOMProp as _setDOMProp, delegateEvents as _delegateEvents, template as _template } from 'vue/vapor';
+"import { delegate as _delegate, setInheritAttrs as _setInheritAttrs, renderEffect as _renderEffect, setText as _setText, setAsProp as _setAsProp, delegateEvents as _delegateEvents, template as _template } from 'vue/vapor';
 const t0 = _template("<button></button>")
 _delegateEvents("click")
 
@@ -186,7 +186,7 @@ export function render(_ctx) {
   _delegate(n0, "click", () => _ctx.handleClick)
   _setInheritAttrs(["id"])
   _renderEffect(() => _setText(n0, _ctx.count, "foo", _ctx.count, "foo", _ctx.count))
-  _renderEffect(() => _setDOMProp(n0, "id", _ctx.count, true))
+  _renderEffect(() => _setAsProp(n0, "id", _ctx.count, true))
   return n0
 }"
 `;

--- a/packages/compiler-vapor/__tests__/transforms/__snapshots__/vBind.spec.ts.snap
+++ b/packages/compiler-vapor/__tests__/transforms/__snapshots__/vBind.spec.ts.snap
@@ -7,7 +7,7 @@ const t0 = _template("<div></div>")
 export function render(_ctx) {
   const n0 = t0()
   _setInheritAttrs(["foo-bar"])
-  _renderEffect(() => _setAttr(n0, "foo-bar", _ctx.id, true))
+  _renderEffect(() => _setAttr(n0, "foo-bar", _ctx.id))
   return n0
 }"
 `;
@@ -19,7 +19,7 @@ const t0 = _template("<div></div>")
 export function render(_ctx) {
   const n0 = t0()
   _setInheritAttrs(["innerHTML"])
-  _renderEffect(() => _setAttr(n0, "innerHTML", _ctx.foo, true))
+  _renderEffect(() => _setAttr(n0, "innerHTML", _ctx.foo))
   return n0
 }"
 `;
@@ -31,7 +31,7 @@ const t0 = _template("<div></div>")
 export function render(_ctx) {
   const n0 = t0()
   _setInheritAttrs(["foo-bar"])
-  _renderEffect(() => _setAttr(n0, "foo-bar", _ctx.fooBar, true))
+  _renderEffect(() => _setAttr(n0, "foo-bar", _ctx.fooBar))
   return n0
 }"
 `;
@@ -43,7 +43,7 @@ const t0 = _template("<progress></progress>")
 export function render(_ctx) {
   const n0 = t0()
   _setInheritAttrs(["value"])
-  _renderEffect(() => _setAttr(n0, "value", _ctx.foo, true))
+  _renderEffect(() => _setAttr(n0, "value", _ctx.foo))
   return n0
 }"
 `;
@@ -55,7 +55,7 @@ const t0 = _template("<div></div>")
 export function render(_ctx) {
   const n0 = t0()
   _setInheritAttrs(["textContent"])
-  _renderEffect(() => _setAttr(n0, "textContent", _ctx.foo, true))
+  _renderEffect(() => _setAttr(n0, "textContent", _ctx.foo))
   return n0
 }"
 `;
@@ -67,7 +67,7 @@ const t0 = _template("<div></div>")
 export function render(_ctx) {
   const n0 = t0()
   _setInheritAttrs(["value"])
-  _renderEffect(() => _setAttr(n0, "value", _ctx.foo, true))
+  _renderEffect(() => _setAttr(n0, "value", _ctx.foo))
   return n0
 }"
 `;
@@ -79,7 +79,7 @@ const t0 = _template("<div></div>")
 export function render(_ctx) {
   const n0 = t0()
   _setInheritAttrs(["fooBar"])
-  _renderEffect(() => _setDynamicProp(n0, "fooBar", _ctx.id, true))
+  _renderEffect(() => _setDynamicProp(n0, "fooBar", _ctx.id))
   return n0
 }"
 `;
@@ -104,19 +104,7 @@ const t0 = _template("<div></div>")
 export function render(_ctx) {
   const n0 = t0()
   _setInheritAttrs(["fooBar"])
-  _renderEffect(() => _setDynamicProp(n0, "fooBar", _ctx.fooBar, true))
-  return n0
-}"
-`;
-
-exports[`compiler v-bind > .prop modifier (shortband) w/ no expression 1`] = `
-"import { setInheritAttrs as _setInheritAttrs, renderEffect as _renderEffect, setDOMProp as _setDOMProp, template as _template } from 'vue/vapor';
-const t0 = _template("<div></div>")
-
-export function render(_ctx) {
-  const n0 = t0()
-  _setInheritAttrs(["fooBar"])
-  _renderEffect(() => _setDOMProp(n0, "fooBar", _ctx.fooBar, true))
+  _renderEffect(() => _setDynamicProp(n0, "fooBar", _ctx.fooBar))
   return n0
 }"
 `;
@@ -128,7 +116,7 @@ const t0 = _template("<div></div>")
 export function render(_ctx) {
   const n0 = t0()
   _setInheritAttrs(["fooBar"])
-  _renderEffect(() => _setDOMProp(n0, "fooBar", _ctx.id, true))
+  _renderEffect(() => _setDOMProp(n0, "fooBar", _ctx.id))
   return n0
 }"
 `;
@@ -140,7 +128,7 @@ const t0 = _template("<div></div>")
 export function render(_ctx) {
   const n0 = t0()
   _setInheritAttrs(["innerHTML"])
-  _renderEffect(() => _setHtml(n0, _ctx.foo, true))
+  _renderEffect(() => _setHtml(n0, _ctx.foo))
   return n0
 }"
 `;
@@ -152,7 +140,7 @@ const t0 = _template("<div></div>")
 export function render(_ctx) {
   const n0 = t0()
   _setInheritAttrs(["fooBar"])
-  _renderEffect(() => _setDOMProp(n0, "fooBar", _ctx.fooBar, true))
+  _renderEffect(() => _setDOMProp(n0, "fooBar", _ctx.fooBar))
   return n0
 }"
 `;
@@ -164,7 +152,7 @@ const t0 = _template("<progress></progress>")
 export function render(_ctx) {
   const n0 = t0()
   _setInheritAttrs(["value"])
-  _renderEffect(() => _setDOMProp(n0, "value", _ctx.foo, true))
+  _renderEffect(() => _setDOMProp(n0, "value", _ctx.foo))
   return n0
 }"
 `;
@@ -176,7 +164,7 @@ const t0 = _template("<div></div>")
 export function render(_ctx) {
   const n0 = t0()
   _setInheritAttrs(["textContent"])
-  _renderEffect(() => _setText(n0, _ctx.foo, true))
+  _renderEffect(() => _setText(n0, _ctx.foo))
   return n0
 }"
 `;
@@ -188,7 +176,7 @@ const t0 = _template("<div></div>")
 export function render(_ctx) {
   const n0 = t0()
   _setInheritAttrs(["value"])
-  _renderEffect(() => _setValue(n0, _ctx.foo, true))
+  _renderEffect(() => _setValue(n0, _ctx.foo))
   return n0
 }"
 `;
@@ -200,7 +188,7 @@ const t0 = _template("<div></div>")
 export function render(_ctx) {
   const n0 = t0()
   _setInheritAttrs(["fooBar"])
-  _renderEffect(() => _setDOMProp(n0, "fooBar", _ctx.id, true))
+  _renderEffect(() => _setDOMProp(n0, "fooBar", _ctx.id))
   return n0
 }"
 `;
@@ -224,7 +212,7 @@ const t0 = _template("<div></div>")
 export function render(_ctx) {
   const n0 = t0()
   _setInheritAttrs(["innerHTML"])
-  _renderEffect(() => _setHtml(n0, _ctx.foo, true))
+  _renderEffect(() => _setHtml(n0, _ctx.foo))
   return n0
 }"
 `;
@@ -236,7 +224,7 @@ const t0 = _template("<div></div>")
 export function render(_ctx) {
   const n0 = t0()
   _setInheritAttrs(["fooBar"])
-  _renderEffect(() => _setDOMProp(n0, "fooBar", _ctx.fooBar, true))
+  _renderEffect(() => _setDOMProp(n0, "fooBar", _ctx.fooBar))
   return n0
 }"
 `;
@@ -248,7 +236,7 @@ const t0 = _template("<progress></progress>")
 export function render(_ctx) {
   const n0 = t0()
   _setInheritAttrs(["value"])
-  _renderEffect(() => _setDOMProp(n0, "value", _ctx.foo, true))
+  _renderEffect(() => _setDOMProp(n0, "value", _ctx.foo))
   return n0
 }"
 `;
@@ -260,7 +248,7 @@ const t0 = _template("<div></div>")
 export function render(_ctx) {
   const n0 = t0()
   _setInheritAttrs(["textContent"])
-  _renderEffect(() => _setText(n0, _ctx.foo, true))
+  _renderEffect(() => _setText(n0, _ctx.foo))
   return n0
 }"
 `;
@@ -272,7 +260,7 @@ const t0 = _template("<div></div>")
 export function render(_ctx) {
   const n0 = t0()
   _setInheritAttrs(["value"])
-  _renderEffect(() => _setValue(n0, _ctx.foo, true))
+  _renderEffect(() => _setValue(n0, _ctx.foo))
   return n0
 }"
 `;
@@ -284,7 +272,7 @@ const t0 = _template("<div></div>")
 export function render(_ctx) {
   const n0 = t0()
   _setInheritAttrs(["innerHTML"])
-  _renderEffect(() => _setHtml(n0, _ctx.foo, true))
+  _renderEffect(() => _setHtml(n0, _ctx.foo))
   return n0
 }"
 `;
@@ -296,7 +284,7 @@ const t0 = _template("<div></div>")
 export function render(_ctx) {
   const n0 = t0()
   _setInheritAttrs(["textContent"])
-  _renderEffect(() => _setText(n0, _ctx.foo, true))
+  _renderEffect(() => _setText(n0, _ctx.foo))
   return n0
 }"
 `;
@@ -308,7 +296,7 @@ const t0 = _template("<input>")
 export function render(_ctx) {
   const n0 = t0()
   _setInheritAttrs(["value"])
-  _renderEffect(() => _setValue(n0, _ctx.foo, true))
+  _renderEffect(() => _setValue(n0, _ctx.foo))
   return n0
 }"
 `;
@@ -320,7 +308,7 @@ const t0 = _template("<progress></progress>")
 export function render(_ctx) {
   const n0 = t0()
   _setInheritAttrs(["value"])
-  _renderEffect(() => _setDynamicProp(n0, "value", _ctx.foo, true))
+  _renderEffect(() => _setDynamicProp(n0, "value", _ctx.foo))
   return n0
 }"
 `;
@@ -332,11 +320,11 @@ const t0 = _template("<div></div>")
 export function render(_ctx) {
   const n0 = t0()
   _setInheritAttrs(["id", "title", "lang", "dir", "tabindex"])
-  _renderEffect(() => _setDOMProp(n0, "id", _ctx.id, true))
-  _renderEffect(() => _setDOMProp(n0, "title", _ctx.title, true))
-  _renderEffect(() => _setDOMProp(n0, "lang", _ctx.lang, true))
-  _renderEffect(() => _setDOMProp(n0, "dir", _ctx.dir, true))
-  _renderEffect(() => _setDOMProp(n0, "tabindex", _ctx.tabindex, true))
+  _renderEffect(() => _setDOMProp(n0, "id", _ctx.id))
+  _renderEffect(() => _setDOMProp(n0, "title", _ctx.title))
+  _renderEffect(() => _setDOMProp(n0, "lang", _ctx.lang))
+  _renderEffect(() => _setDOMProp(n0, "dir", _ctx.dir))
+  _renderEffect(() => _setDOMProp(n0, "tabindex", _ctx.tabindex))
   return n0
 }"
 `;
@@ -348,11 +336,11 @@ const t0 = _template("<math></math>")
 export function render(_ctx) {
   const n0 = t0()
   _setInheritAttrs(["autofucus", "dir", "displaystyle", "mathcolor", "tabindex"])
-  _renderEffect(() => _setDOMProp(n0, "autofucus", _ctx.autofucus, true))
-  _renderEffect(() => _setDOMProp(n0, "dir", _ctx.dir, true))
-  _renderEffect(() => _setDOMProp(n0, "displaystyle", _ctx.displaystyle, true))
-  _renderEffect(() => _setDOMProp(n0, "mathcolor", _ctx.mathcolor, true))
-  _renderEffect(() => _setDOMProp(n0, "tabindex", _ctx.tabindex, true))
+  _renderEffect(() => _setDOMProp(n0, "autofucus", _ctx.autofucus))
+  _renderEffect(() => _setDOMProp(n0, "dir", _ctx.dir))
+  _renderEffect(() => _setDOMProp(n0, "displaystyle", _ctx.displaystyle))
+  _renderEffect(() => _setDOMProp(n0, "mathcolor", _ctx.mathcolor))
+  _renderEffect(() => _setDOMProp(n0, "tabindex", _ctx.tabindex))
   return n0
 }"
 `;
@@ -364,9 +352,9 @@ const t0 = _template("<svg></svg>")
 export function render(_ctx) {
   const n0 = t0()
   _setInheritAttrs(["id", "lang", "tabindex"])
-  _renderEffect(() => _setDOMProp(n0, "id", _ctx.id, true))
-  _renderEffect(() => _setDOMProp(n0, "lang", _ctx.lang, true))
-  _renderEffect(() => _setDOMProp(n0, "tabindex", _ctx.tabindex, true))
+  _renderEffect(() => _setDOMProp(n0, "id", _ctx.id))
+  _renderEffect(() => _setDOMProp(n0, "lang", _ctx.lang))
+  _renderEffect(() => _setDOMProp(n0, "tabindex", _ctx.tabindex))
   return n0
 }"
 `;
@@ -418,7 +406,7 @@ const t0 = _template("<div></div>")
 export function render(_ctx) {
   const n0 = t0()
   _setInheritAttrs(["id"])
-  _renderEffect(() => _setDOMProp(n0, "id", _ctx.id, true))
+  _renderEffect(() => _setDOMProp(n0, "id", _ctx.id))
   return n0
 }"
 `;
@@ -454,7 +442,7 @@ const t0 = _template("<div></div>")
 export function render(_ctx) {
   const n0 = t0()
   _setInheritAttrs(["camel-case"])
-  _renderEffect(() => _setDynamicProp(n0, "camel-case", _ctx.camelCase, true))
+  _renderEffect(() => _setDynamicProp(n0, "camel-case", _ctx.camelCase))
   return n0
 }"
 `;
@@ -466,7 +454,7 @@ const t0 = _template("<div></div>")
 export function render(_ctx) {
   const n0 = t0()
   _setInheritAttrs(["id"])
-  _renderEffect(() => _setDOMProp(n0, "id", _ctx.id, true))
+  _renderEffect(() => _setDOMProp(n0, "id", _ctx.id))
   return n0
 }"
 `;

--- a/packages/compiler-vapor/__tests__/transforms/__snapshots__/vBind.spec.ts.snap
+++ b/packages/compiler-vapor/__tests__/transforms/__snapshots__/vBind.spec.ts.snap
@@ -12,6 +12,18 @@ export function render(_ctx) {
 }"
 `;
 
+exports[`compiler v-bind > .attr modifier w/ innerHTML 1`] = `
+"import { setInheritAttrs as _setInheritAttrs, renderEffect as _renderEffect, setAttr as _setAttr, template as _template } from 'vue/vapor';
+const t0 = _template("<div></div>")
+
+export function render(_ctx) {
+  const n0 = t0()
+  _setInheritAttrs(["innerHTML"])
+  _renderEffect(() => _setAttr(n0, "innerHTML", _ctx.foo, true))
+  return n0
+}"
+`;
+
 exports[`compiler v-bind > .attr modifier w/ no expression 1`] = `
 "import { setInheritAttrs as _setInheritAttrs, renderEffect as _renderEffect, setAttr as _setAttr, template as _template } from 'vue/vapor';
 const t0 = _template("<div></div>")
@@ -20,6 +32,42 @@ export function render(_ctx) {
   const n0 = t0()
   _setInheritAttrs(["foo-bar"])
   _renderEffect(() => _setAttr(n0, "foo-bar", _ctx.fooBar, true))
+  return n0
+}"
+`;
+
+exports[`compiler v-bind > .attr modifier w/ progress value 1`] = `
+"import { setInheritAttrs as _setInheritAttrs, renderEffect as _renderEffect, setAttr as _setAttr, template as _template } from 'vue/vapor';
+const t0 = _template("<progress></progress>")
+
+export function render(_ctx) {
+  const n0 = t0()
+  _setInheritAttrs(["value"])
+  _renderEffect(() => _setAttr(n0, "value", _ctx.foo, true))
+  return n0
+}"
+`;
+
+exports[`compiler v-bind > .attr modifier w/ textContent 1`] = `
+"import { setInheritAttrs as _setInheritAttrs, renderEffect as _renderEffect, setAttr as _setAttr, template as _template } from 'vue/vapor';
+const t0 = _template("<div></div>")
+
+export function render(_ctx) {
+  const n0 = t0()
+  _setInheritAttrs(["textContent"])
+  _renderEffect(() => _setAttr(n0, "textContent", _ctx.foo, true))
+  return n0
+}"
+`;
+
+exports[`compiler v-bind > .attr modifier w/ value 1`] = `
+"import { setInheritAttrs as _setInheritAttrs, renderEffect as _renderEffect, setAttr as _setAttr, template as _template } from 'vue/vapor';
+const t0 = _template("<div></div>")
+
+export function render(_ctx) {
+  const n0 = t0()
+  _setInheritAttrs(["value"])
+  _renderEffect(() => _setAttr(n0, "value", _ctx.foo, true))
   return n0
 }"
 `;
@@ -85,6 +133,66 @@ export function render(_ctx) {
 }"
 `;
 
+exports[`compiler v-bind > .prop modifier (shorthand) w/ innerHTML 1`] = `
+"import { setInheritAttrs as _setInheritAttrs, renderEffect as _renderEffect, setHtml as _setHtml, template as _template } from 'vue/vapor';
+const t0 = _template("<div></div>")
+
+export function render(_ctx) {
+  const n0 = t0()
+  _setInheritAttrs(["innerHTML"])
+  _renderEffect(() => _setHtml(n0, _ctx.foo, true))
+  return n0
+}"
+`;
+
+exports[`compiler v-bind > .prop modifier (shorthand) w/ no expression 1`] = `
+"import { setInheritAttrs as _setInheritAttrs, renderEffect as _renderEffect, setDOMProp as _setDOMProp, template as _template } from 'vue/vapor';
+const t0 = _template("<div></div>")
+
+export function render(_ctx) {
+  const n0 = t0()
+  _setInheritAttrs(["fooBar"])
+  _renderEffect(() => _setDOMProp(n0, "fooBar", _ctx.fooBar, true))
+  return n0
+}"
+`;
+
+exports[`compiler v-bind > .prop modifier (shorthand) w/ progress value 1`] = `
+"import { setInheritAttrs as _setInheritAttrs, renderEffect as _renderEffect, setDOMProp as _setDOMProp, template as _template } from 'vue/vapor';
+const t0 = _template("<progress></progress>")
+
+export function render(_ctx) {
+  const n0 = t0()
+  _setInheritAttrs(["value"])
+  _renderEffect(() => _setDOMProp(n0, "value", _ctx.foo, true))
+  return n0
+}"
+`;
+
+exports[`compiler v-bind > .prop modifier (shorthand) w/ textContent 1`] = `
+"import { setInheritAttrs as _setInheritAttrs, renderEffect as _renderEffect, setText as _setText, template as _template } from 'vue/vapor';
+const t0 = _template("<div></div>")
+
+export function render(_ctx) {
+  const n0 = t0()
+  _setInheritAttrs(["textContent"])
+  _renderEffect(() => _setText(n0, _ctx.foo, true))
+  return n0
+}"
+`;
+
+exports[`compiler v-bind > .prop modifier (shorthand) w/ value 1`] = `
+"import { setInheritAttrs as _setInheritAttrs, renderEffect as _renderEffect, setValue as _setValue, template as _template } from 'vue/vapor';
+const t0 = _template("<div></div>")
+
+export function render(_ctx) {
+  const n0 = t0()
+  _setInheritAttrs(["value"])
+  _renderEffect(() => _setValue(n0, _ctx.foo, true))
+  return n0
+}"
+`;
+
 exports[`compiler v-bind > .prop modifier 1`] = `
 "import { setInheritAttrs as _setInheritAttrs, renderEffect as _renderEffect, setDOMProp as _setDOMProp, template as _template } from 'vue/vapor';
 const t0 = _template("<div></div>")
@@ -109,6 +217,18 @@ export function render(_ctx) {
 }"
 `;
 
+exports[`compiler v-bind > .prop modifier w/ innerHTML 1`] = `
+"import { setInheritAttrs as _setInheritAttrs, renderEffect as _renderEffect, setHtml as _setHtml, template as _template } from 'vue/vapor';
+const t0 = _template("<div></div>")
+
+export function render(_ctx) {
+  const n0 = t0()
+  _setInheritAttrs(["innerHTML"])
+  _renderEffect(() => _setHtml(n0, _ctx.foo, true))
+  return n0
+}"
+`;
+
 exports[`compiler v-bind > .prop modifier w/ no expression 1`] = `
 "import { setInheritAttrs as _setInheritAttrs, renderEffect as _renderEffect, setDOMProp as _setDOMProp, template as _template } from 'vue/vapor';
 const t0 = _template("<div></div>")
@@ -117,6 +237,42 @@ export function render(_ctx) {
   const n0 = t0()
   _setInheritAttrs(["fooBar"])
   _renderEffect(() => _setDOMProp(n0, "fooBar", _ctx.fooBar, true))
+  return n0
+}"
+`;
+
+exports[`compiler v-bind > .prop modifier w/ progress value 1`] = `
+"import { setInheritAttrs as _setInheritAttrs, renderEffect as _renderEffect, setDOMProp as _setDOMProp, template as _template } from 'vue/vapor';
+const t0 = _template("<progress></progress>")
+
+export function render(_ctx) {
+  const n0 = t0()
+  _setInheritAttrs(["value"])
+  _renderEffect(() => _setDOMProp(n0, "value", _ctx.foo, true))
+  return n0
+}"
+`;
+
+exports[`compiler v-bind > .prop modifier w/ textContent 1`] = `
+"import { setInheritAttrs as _setInheritAttrs, renderEffect as _renderEffect, setText as _setText, template as _template } from 'vue/vapor';
+const t0 = _template("<div></div>")
+
+export function render(_ctx) {
+  const n0 = t0()
+  _setInheritAttrs(["textContent"])
+  _renderEffect(() => _setText(n0, _ctx.foo, true))
+  return n0
+}"
+`;
+
+exports[`compiler v-bind > .prop modifier w/ value 1`] = `
+"import { setInheritAttrs as _setInheritAttrs, renderEffect as _renderEffect, setValue as _setValue, template as _template } from 'vue/vapor';
+const t0 = _template("<div></div>")
+
+export function render(_ctx) {
+  const n0 = t0()
+  _setInheritAttrs(["value"])
+  _renderEffect(() => _setValue(n0, _ctx.foo, true))
   return n0
 }"
 `;

--- a/packages/compiler-vapor/__tests__/transforms/__snapshots__/vBind.spec.ts.snap
+++ b/packages/compiler-vapor/__tests__/transforms/__snapshots__/vBind.spec.ts.snap
@@ -121,48 +121,96 @@ export function render(_ctx) {
 }"
 `;
 
+exports[`compiler v-bind > :innerHTML 1`] = `
+"import { setInheritAttrs as _setInheritAttrs, renderEffect as _renderEffect, setHtml as _setHtml, template as _template } from 'vue/vapor';
+const t0 = _template("<div></div>")
+
+export function render(_ctx) {
+  const n0 = t0()
+  _setInheritAttrs(["innerHTML"])
+  _renderEffect(() => _setHtml(n0, _ctx.foo, true))
+  return n0
+}"
+`;
+
+exports[`compiler v-bind > :textContext 1`] = `
+"import { setInheritAttrs as _setInheritAttrs, renderEffect as _renderEffect, setText as _setText, template as _template } from 'vue/vapor';
+const t0 = _template("<div></div>")
+
+export function render(_ctx) {
+  const n0 = t0()
+  _setInheritAttrs(["textContent"])
+  _renderEffect(() => _setText(n0, _ctx.foo, true))
+  return n0
+}"
+`;
+
+exports[`compiler v-bind > :value 1`] = `
+"import { setInheritAttrs as _setInheritAttrs, renderEffect as _renderEffect, setValue as _setValue, template as _template } from 'vue/vapor';
+const t0 = _template("<input>")
+
+export function render(_ctx) {
+  const n0 = t0()
+  _setInheritAttrs(["value"])
+  _renderEffect(() => _setValue(n0, _ctx.foo, true))
+  return n0
+}"
+`;
+
+exports[`compiler v-bind > :value w/ progress 1`] = `
+"import { setInheritAttrs as _setInheritAttrs, renderEffect as _renderEffect, setDynamicProp as _setDynamicProp, template as _template } from 'vue/vapor';
+const t0 = _template("<progress></progress>")
+
+export function render(_ctx) {
+  const n0 = t0()
+  _setInheritAttrs(["value"])
+  _renderEffect(() => _setDynamicProp(n0, "value", _ctx.foo, true))
+  return n0
+}"
+`;
+
 exports[`compiler v-bind > HTML global attributes should set as dom prop 1`] = `
-"import { setInheritAttrs as _setInheritAttrs, renderEffect as _renderEffect, setDOMProp as _setDOMProp, template as _template } from 'vue/vapor';
+"import { setInheritAttrs as _setInheritAttrs, renderEffect as _renderEffect, setAsProp as _setAsProp, template as _template } from 'vue/vapor';
 const t0 = _template("<div></div>")
 
 export function render(_ctx) {
   const n0 = t0()
   _setInheritAttrs(["id", "title", "lang", "dir", "tabindex"])
-  _renderEffect(() => _setDOMProp(n0, "id", _ctx.id, true))
-  _renderEffect(() => _setDOMProp(n0, "title", _ctx.title, true))
-  _renderEffect(() => _setDOMProp(n0, "lang", _ctx.lang, true))
-  _renderEffect(() => _setDOMProp(n0, "dir", _ctx.dir, true))
-  _renderEffect(() => _setDOMProp(n0, "tabindex", _ctx.tabindex, true))
+  _renderEffect(() => _setAsProp(n0, "id", _ctx.id, true))
+  _renderEffect(() => _setAsProp(n0, "title", _ctx.title, true))
+  _renderEffect(() => _setAsProp(n0, "lang", _ctx.lang, true))
+  _renderEffect(() => _setAsProp(n0, "dir", _ctx.dir, true))
+  _renderEffect(() => _setAsProp(n0, "tabindex", _ctx.tabindex, true))
   return n0
 }"
 `;
 
 exports[`compiler v-bind > MathML global attributes should set as dom prop 1`] = `
-"import { setInheritAttrs as _setInheritAttrs, renderEffect as _renderEffect, setDOMProp as _setDOMProp, template as _template } from 'vue/vapor';
+"import { setInheritAttrs as _setInheritAttrs, renderEffect as _renderEffect, setAsProp as _setAsProp, template as _template } from 'vue/vapor';
 const t0 = _template("<math></math>")
 
 export function render(_ctx) {
   const n0 = t0()
   _setInheritAttrs(["autofucus", "dir", "displaystyle", "mathcolor", "tabindex"])
-  _renderEffect(() => _setDOMProp(n0, "autofucus", _ctx.autofucus, true))
-  _renderEffect(() => _setDOMProp(n0, "dir", _ctx.dir, true))
-  _renderEffect(() => _setDOMProp(n0, "displaystyle", _ctx.displaystyle, true))
-  _renderEffect(() => _setDOMProp(n0, "mathcolor", _ctx.mathcolor, true))
-  _renderEffect(() => _setDOMProp(n0, "tabindex", _ctx.tabindex, true))
+  _renderEffect(() => _setAsProp(n0, "autofucus", _ctx.autofucus, true))
+  _renderEffect(() => _setAsProp(n0, "dir", _ctx.dir, true))
+  _renderEffect(() => _setAsProp(n0, "displaystyle", _ctx.displaystyle, true))
+  _renderEffect(() => _setAsProp(n0, "mathcolor", _ctx.mathcolor, true))
+  _renderEffect(() => _setAsProp(n0, "tabindex", _ctx.tabindex, true))
   return n0
 }"
 `;
 
 exports[`compiler v-bind > SVG global attributes should set as dom prop 1`] = `
-"import { setInheritAttrs as _setInheritAttrs, renderEffect as _renderEffect, setDOMProp as _setDOMProp, template as _template } from 'vue/vapor';
+"import { setInheritAttrs as _setInheritAttrs, renderEffect as _renderEffect, setAsProp as _setAsProp, template as _template } from 'vue/vapor';
 const t0 = _template("<svg></svg>")
 
 export function render(_ctx) {
   const n0 = t0()
   _setInheritAttrs(["id", "lang", "tabindex"])
-  _renderEffect(() => _setDOMProp(n0, "id", _ctx.id, true))
-  _renderEffect(() => _setDOMProp(n0, "lang", _ctx.lang, true))
-  _renderEffect(() => _setDOMProp(n0, "tabindex", _ctx.tabindex, true))
+  _renderEffect(() => _setAsProp(n0, "id", _ctx.id, true))
+  _renderEffect(() => _setAsProp(n0, "lang", _ctx.lang, true))
+  _renderEffect(() => _setAsProp(n0, "tabindex", _ctx.tabindex, true))
   return n0
 }"
 `;
@@ -208,13 +256,13 @@ export function render(_ctx) {
 `;
 
 exports[`compiler v-bind > basic 1`] = `
-"import { setInheritAttrs as _setInheritAttrs, renderEffect as _renderEffect, setDOMProp as _setDOMProp, template as _template } from 'vue/vapor';
+"import { setInheritAttrs as _setInheritAttrs, renderEffect as _renderEffect, setAsProp as _setAsProp, template as _template } from 'vue/vapor';
 const t0 = _template("<div></div>")
 
 export function render(_ctx) {
   const n0 = t0()
   _setInheritAttrs(["id"])
-  _renderEffect(() => _setDOMProp(n0, "id", _ctx.id, true))
+  _renderEffect(() => _setAsProp(n0, "id", _ctx.id, true))
   return n0
 }"
 `;
@@ -256,13 +304,13 @@ export function render(_ctx) {
 `;
 
 exports[`compiler v-bind > no expression 1`] = `
-"import { setInheritAttrs as _setInheritAttrs, renderEffect as _renderEffect, setDOMProp as _setDOMProp, template as _template } from 'vue/vapor';
+"import { setInheritAttrs as _setInheritAttrs, renderEffect as _renderEffect, setAsProp as _setAsProp, template as _template } from 'vue/vapor';
 const t0 = _template("<div></div>")
 
 export function render(_ctx) {
   const n0 = t0()
   _setInheritAttrs(["id"])
-  _renderEffect(() => _setDOMProp(n0, "id", _ctx.id, true))
+  _renderEffect(() => _setAsProp(n0, "id", _ctx.id, true))
   return n0
 }"
 `;

--- a/packages/compiler-vapor/__tests__/transforms/__snapshots__/vBind.spec.ts.snap
+++ b/packages/compiler-vapor/__tests__/transforms/__snapshots__/vBind.spec.ts.snap
@@ -170,47 +170,47 @@ export function render(_ctx) {
 `;
 
 exports[`compiler v-bind > HTML global attributes should set as dom prop 1`] = `
-"import { setInheritAttrs as _setInheritAttrs, renderEffect as _renderEffect, setAsProp as _setAsProp, template as _template } from 'vue/vapor';
+"import { setInheritAttrs as _setInheritAttrs, renderEffect as _renderEffect, setDOMProp as _setDOMProp, template as _template } from 'vue/vapor';
 const t0 = _template("<div></div>")
 
 export function render(_ctx) {
   const n0 = t0()
   _setInheritAttrs(["id", "title", "lang", "dir", "tabindex"])
-  _renderEffect(() => _setAsProp(n0, "id", _ctx.id, true))
-  _renderEffect(() => _setAsProp(n0, "title", _ctx.title, true))
-  _renderEffect(() => _setAsProp(n0, "lang", _ctx.lang, true))
-  _renderEffect(() => _setAsProp(n0, "dir", _ctx.dir, true))
-  _renderEffect(() => _setAsProp(n0, "tabindex", _ctx.tabindex, true))
+  _renderEffect(() => _setDOMProp(n0, "id", _ctx.id, true))
+  _renderEffect(() => _setDOMProp(n0, "title", _ctx.title, true))
+  _renderEffect(() => _setDOMProp(n0, "lang", _ctx.lang, true))
+  _renderEffect(() => _setDOMProp(n0, "dir", _ctx.dir, true))
+  _renderEffect(() => _setDOMProp(n0, "tabindex", _ctx.tabindex, true))
   return n0
 }"
 `;
 
 exports[`compiler v-bind > MathML global attributes should set as dom prop 1`] = `
-"import { setInheritAttrs as _setInheritAttrs, renderEffect as _renderEffect, setAsProp as _setAsProp, template as _template } from 'vue/vapor';
+"import { setInheritAttrs as _setInheritAttrs, renderEffect as _renderEffect, setDOMProp as _setDOMProp, template as _template } from 'vue/vapor';
 const t0 = _template("<math></math>")
 
 export function render(_ctx) {
   const n0 = t0()
   _setInheritAttrs(["autofucus", "dir", "displaystyle", "mathcolor", "tabindex"])
-  _renderEffect(() => _setAsProp(n0, "autofucus", _ctx.autofucus, true))
-  _renderEffect(() => _setAsProp(n0, "dir", _ctx.dir, true))
-  _renderEffect(() => _setAsProp(n0, "displaystyle", _ctx.displaystyle, true))
-  _renderEffect(() => _setAsProp(n0, "mathcolor", _ctx.mathcolor, true))
-  _renderEffect(() => _setAsProp(n0, "tabindex", _ctx.tabindex, true))
+  _renderEffect(() => _setDOMProp(n0, "autofucus", _ctx.autofucus, true))
+  _renderEffect(() => _setDOMProp(n0, "dir", _ctx.dir, true))
+  _renderEffect(() => _setDOMProp(n0, "displaystyle", _ctx.displaystyle, true))
+  _renderEffect(() => _setDOMProp(n0, "mathcolor", _ctx.mathcolor, true))
+  _renderEffect(() => _setDOMProp(n0, "tabindex", _ctx.tabindex, true))
   return n0
 }"
 `;
 
 exports[`compiler v-bind > SVG global attributes should set as dom prop 1`] = `
-"import { setInheritAttrs as _setInheritAttrs, renderEffect as _renderEffect, setAsProp as _setAsProp, template as _template } from 'vue/vapor';
+"import { setInheritAttrs as _setInheritAttrs, renderEffect as _renderEffect, setDOMProp as _setDOMProp, template as _template } from 'vue/vapor';
 const t0 = _template("<svg></svg>")
 
 export function render(_ctx) {
   const n0 = t0()
   _setInheritAttrs(["id", "lang", "tabindex"])
-  _renderEffect(() => _setAsProp(n0, "id", _ctx.id, true))
-  _renderEffect(() => _setAsProp(n0, "lang", _ctx.lang, true))
-  _renderEffect(() => _setAsProp(n0, "tabindex", _ctx.tabindex, true))
+  _renderEffect(() => _setDOMProp(n0, "id", _ctx.id, true))
+  _renderEffect(() => _setDOMProp(n0, "lang", _ctx.lang, true))
+  _renderEffect(() => _setDOMProp(n0, "tabindex", _ctx.tabindex, true))
   return n0
 }"
 `;
@@ -256,13 +256,13 @@ export function render(_ctx) {
 `;
 
 exports[`compiler v-bind > basic 1`] = `
-"import { setInheritAttrs as _setInheritAttrs, renderEffect as _renderEffect, setAsProp as _setAsProp, template as _template } from 'vue/vapor';
+"import { setInheritAttrs as _setInheritAttrs, renderEffect as _renderEffect, setDOMProp as _setDOMProp, template as _template } from 'vue/vapor';
 const t0 = _template("<div></div>")
 
 export function render(_ctx) {
   const n0 = t0()
   _setInheritAttrs(["id"])
-  _renderEffect(() => _setAsProp(n0, "id", _ctx.id, true))
+  _renderEffect(() => _setDOMProp(n0, "id", _ctx.id, true))
   return n0
 }"
 `;
@@ -304,13 +304,13 @@ export function render(_ctx) {
 `;
 
 exports[`compiler v-bind > no expression 1`] = `
-"import { setInheritAttrs as _setInheritAttrs, renderEffect as _renderEffect, setAsProp as _setAsProp, template as _template } from 'vue/vapor';
+"import { setInheritAttrs as _setInheritAttrs, renderEffect as _renderEffect, setDOMProp as _setDOMProp, template as _template } from 'vue/vapor';
 const t0 = _template("<div></div>")
 
 export function render(_ctx) {
   const n0 = t0()
   _setInheritAttrs(["id"])
-  _renderEffect(() => _setAsProp(n0, "id", _ctx.id, true))
+  _renderEffect(() => _setDOMProp(n0, "id", _ctx.id, true))
   return n0
 }"
 `;

--- a/packages/compiler-vapor/__tests__/transforms/__snapshots__/vFor.spec.ts.snap
+++ b/packages/compiler-vapor/__tests__/transforms/__snapshots__/vFor.spec.ts.snap
@@ -52,8 +52,8 @@ export function render(_ctx) {
   const n0 = _createFor(() => (_ctx.items), (_ctx0) => {
     const n2 = t0()
     _setInheritAttrs(["item", "index"])
-    _renderEffect(() => _setDynamicProp(n2, "item", _ctx0[0].value, true))
-    _renderEffect(() => _setDynamicProp(n2, "index", _ctx0[1].value, true))
+    _renderEffect(() => _setDynamicProp(n2, "item", _ctx0[0].value))
+    _renderEffect(() => _setDynamicProp(n2, "index", _ctx0[1].value))
     return n2
   })
   return n0

--- a/packages/compiler-vapor/__tests__/transforms/__snapshots__/vOnce.spec.ts.snap
+++ b/packages/compiler-vapor/__tests__/transforms/__snapshots__/vOnce.spec.ts.snap
@@ -6,7 +6,7 @@ const t0 = _template("<div></div>")
 
 export function render(_ctx) {
   const n0 = t0()
-  _setDOMProp(n0, "id", _ctx.foo, true)
+  _setDOMProp(n0, "id", _ctx.foo)
   _setInheritAttrs(["id"])
   return n0
 }"

--- a/packages/compiler-vapor/__tests__/transforms/__snapshots__/vOnce.spec.ts.snap
+++ b/packages/compiler-vapor/__tests__/transforms/__snapshots__/vOnce.spec.ts.snap
@@ -1,12 +1,12 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`compiler: v-once > as root node 1`] = `
-"import { setDOMProp as _setDOMProp, setInheritAttrs as _setInheritAttrs, template as _template } from 'vue/vapor';
+"import { setAsProp as _setAsProp, setInheritAttrs as _setInheritAttrs, template as _template } from 'vue/vapor';
 const t0 = _template("<div></div>")
 
 export function render(_ctx) {
   const n0 = t0()
-  _setDOMProp(n0, "id", _ctx.foo, true)
+  _setAsProp(n0, "id", _ctx.foo, true)
   _setInheritAttrs(["id"])
   return n0
 }"
@@ -52,13 +52,13 @@ export function render(_ctx) {
 `;
 
 exports[`compiler: v-once > on nested plain element 1`] = `
-"import { setDOMProp as _setDOMProp, template as _template } from 'vue/vapor';
+"import { setAsProp as _setAsProp, template as _template } from 'vue/vapor';
 const t0 = _template("<div><div></div></div>")
 
 export function render(_ctx) {
   const n1 = t0()
   const n0 = n1.firstChild
-  _setDOMProp(n0, "id", _ctx.foo)
+  _setAsProp(n0, "id", _ctx.foo)
   return n1
 }"
 `;

--- a/packages/compiler-vapor/__tests__/transforms/__snapshots__/vOnce.spec.ts.snap
+++ b/packages/compiler-vapor/__tests__/transforms/__snapshots__/vOnce.spec.ts.snap
@@ -1,12 +1,12 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`compiler: v-once > as root node 1`] = `
-"import { setAsProp as _setAsProp, setInheritAttrs as _setInheritAttrs, template as _template } from 'vue/vapor';
+"import { setDOMProp as _setDOMProp, setInheritAttrs as _setInheritAttrs, template as _template } from 'vue/vapor';
 const t0 = _template("<div></div>")
 
 export function render(_ctx) {
   const n0 = t0()
-  _setAsProp(n0, "id", _ctx.foo, true)
+  _setDOMProp(n0, "id", _ctx.foo, true)
   _setInheritAttrs(["id"])
   return n0
 }"
@@ -52,13 +52,13 @@ export function render(_ctx) {
 `;
 
 exports[`compiler: v-once > on nested plain element 1`] = `
-"import { setAsProp as _setAsProp, template as _template } from 'vue/vapor';
+"import { setDOMProp as _setDOMProp, template as _template } from 'vue/vapor';
 const t0 = _template("<div><div></div></div>")
 
 export function render(_ctx) {
   const n1 = t0()
   const n0 = n1.firstChild
-  _setAsProp(n0, "id", _ctx.foo)
+  _setDOMProp(n0, "id", _ctx.foo)
   return n1
 }"
 `;

--- a/packages/compiler-vapor/__tests__/transforms/vBind.spec.ts
+++ b/packages/compiler-vapor/__tests__/transforms/vBind.spec.ts
@@ -74,7 +74,7 @@ describe('compiler v-bind', () => {
     })
 
     expect(code).matchSnapshot()
-    expect(code).contains('_setDOMProp(n0, "id", _ctx.id, true)')
+    expect(code).contains('_setDOMProp(n0, "id", _ctx.id)')
   })
 
   test('no expression', () => {
@@ -104,7 +104,7 @@ describe('compiler v-bind', () => {
         ],
       },
     })
-    expect(code).contains('_setDOMProp(n0, "id", _ctx.id, true)')
+    expect(code).contains('_setDOMProp(n0, "id", _ctx.id)')
   })
 
   test('no expression (shorthand)', () => {
@@ -126,9 +126,7 @@ describe('compiler v-bind', () => {
         ],
       },
     })
-    expect(code).contains(
-      '_setDynamicProp(n0, "camel-case", _ctx.camelCase, true)',
-    )
+    expect(code).contains('_setDynamicProp(n0, "camel-case", _ctx.camelCase)')
   })
 
   test('dynamic arg', () => {
@@ -288,7 +286,7 @@ describe('compiler v-bind', () => {
     })
 
     expect(code).matchSnapshot()
-    expect(code).contains('_setDynamicProp(n0, "fooBar", _ctx.id, true)')
+    expect(code).contains('_setDynamicProp(n0, "fooBar", _ctx.id)')
   })
 
   test('.camel modifier w/ no expression', () => {
@@ -312,7 +310,7 @@ describe('compiler v-bind', () => {
       },
     })
     expect(code).contains('renderEffect')
-    expect(code).contains('_setDynamicProp(n0, "fooBar", _ctx.fooBar, true)')
+    expect(code).contains('_setDynamicProp(n0, "fooBar", _ctx.fooBar)')
   })
 
   test('.camel modifier w/ dynamic arg', () => {
@@ -370,7 +368,7 @@ describe('compiler v-bind', () => {
       },
     })
     expect(code).contains('renderEffect')
-    expect(code).contains('_setDOMProp(n0, "fooBar", _ctx.id, true)')
+    expect(code).contains('_setDOMProp(n0, "fooBar", _ctx.id)')
   })
 
   test('.prop modifier w/ no expression', () => {
@@ -394,7 +392,7 @@ describe('compiler v-bind', () => {
       },
     })
     expect(code).contains('renderEffect')
-    expect(code).contains('_setDOMProp(n0, "fooBar", _ctx.fooBar, true)')
+    expect(code).contains('_setDOMProp(n0, "fooBar", _ctx.fooBar)')
   })
 
   test('.prop modifier w/ dynamic arg', () => {
@@ -451,7 +449,7 @@ describe('compiler v-bind', () => {
       },
     })
     expect(code).contains('renderEffect')
-    expect(code).contains('_setDOMProp(n0, "fooBar", _ctx.id, true)')
+    expect(code).contains('_setDOMProp(n0, "fooBar", _ctx.id)')
   })
 
   test('.prop modifier (shorthand) w/ no expression', () => {
@@ -475,55 +473,55 @@ describe('compiler v-bind', () => {
       },
     })
     expect(code).contains('renderEffect')
-    expect(code).contains('_setDOMProp(n0, "fooBar", _ctx.fooBar, true)')
+    expect(code).contains('_setDOMProp(n0, "fooBar", _ctx.fooBar)')
   })
 
   test('.prop modifier w/ innerHTML', () => {
     const { code } = compileWithVBind(`<div :innerHTML.prop="foo" />`)
     expect(code).matchSnapshot()
-    expect(code).contains('_setHtml(n0, _ctx.foo, true)')
+    expect(code).contains('_setHtml(n0, _ctx.foo)')
   })
 
   test('.prop modifier (shorthand) w/ innerHTML', () => {
     const { code } = compileWithVBind(`<div .innerHTML="foo" />`)
     expect(code).matchSnapshot()
-    expect(code).contains('_setHtml(n0, _ctx.foo, true)')
+    expect(code).contains('_setHtml(n0, _ctx.foo)')
   })
 
   test('.prop modifier w/ textContent', () => {
     const { code } = compileWithVBind(`<div :textContent.prop="foo" />`)
     expect(code).matchSnapshot()
-    expect(code).contains('_setText(n0, _ctx.foo, true)')
+    expect(code).contains('_setText(n0, _ctx.foo)')
   })
 
   test('.prop modifier (shorthand) w/ textContent', () => {
     const { code } = compileWithVBind(`<div .textContent="foo" />`)
     expect(code).matchSnapshot()
-    expect(code).contains('_setText(n0, _ctx.foo, true)')
+    expect(code).contains('_setText(n0, _ctx.foo)')
   })
 
   test('.prop modifier w/ value', () => {
     const { code } = compileWithVBind(`<div :value.prop="foo" />`)
     expect(code).matchSnapshot()
-    expect(code).contains('_setValue(n0, _ctx.foo, true)')
+    expect(code).contains('_setValue(n0, _ctx.foo)')
   })
 
   test('.prop modifier (shorthand) w/ value', () => {
     const { code } = compileWithVBind(`<div .value="foo" />`)
     expect(code).matchSnapshot()
-    expect(code).contains('_setValue(n0, _ctx.foo, true)')
+    expect(code).contains('_setValue(n0, _ctx.foo)')
   })
 
   test('.prop modifier w/ progress value', () => {
     const { code } = compileWithVBind(`<progress :value.prop="foo" />`)
     expect(code).matchSnapshot()
-    expect(code).contains('_setDOMProp(n0, "value", _ctx.foo, true)')
+    expect(code).contains('_setDOMProp(n0, "value", _ctx.foo)')
   })
 
   test('.prop modifier (shorthand) w/ progress value', () => {
     const { code } = compileWithVBind(`<progress .value="foo" />`)
     expect(code).matchSnapshot()
-    expect(code).contains('_setDOMProp(n0, "value", _ctx.foo, true)')
+    expect(code).contains('_setDOMProp(n0, "value", _ctx.foo)')
   })
 
   test('.attr modifier', () => {
@@ -547,7 +545,7 @@ describe('compiler v-bind', () => {
       },
     })
     expect(code).contains('renderEffect')
-    expect(code).contains('_setAttr(n0, "foo-bar", _ctx.id, true)')
+    expect(code).contains('_setAttr(n0, "foo-bar", _ctx.id)')
   })
 
   test('.attr modifier w/ no expression', () => {
@@ -572,31 +570,31 @@ describe('compiler v-bind', () => {
     })
 
     expect(code).contains('renderEffect')
-    expect(code).contains('_setAttr(n0, "foo-bar", _ctx.fooBar, true)')
+    expect(code).contains('_setAttr(n0, "foo-bar", _ctx.fooBar)')
   })
 
   test('.attr modifier w/ innerHTML', () => {
     const { code } = compileWithVBind(`<div :innerHTML.attr="foo" />`)
     expect(code).matchSnapshot()
-    expect(code).contains('_setAttr(n0, "innerHTML", _ctx.foo, true)')
+    expect(code).contains('_setAttr(n0, "innerHTML", _ctx.foo)')
   })
 
   test('.attr modifier w/ textContent', () => {
     const { code } = compileWithVBind(`<div :textContent.attr="foo" />`)
     expect(code).matchSnapshot()
-    expect(code).contains('_setAttr(n0, "textContent", _ctx.foo, true)')
+    expect(code).contains('_setAttr(n0, "textContent", _ctx.foo)')
   })
 
   test('.attr modifier w/ value', () => {
     const { code } = compileWithVBind(`<div :value.attr="foo" />`)
     expect(code).matchSnapshot()
-    expect(code).contains('_setAttr(n0, "value", _ctx.foo, true)')
+    expect(code).contains('_setAttr(n0, "value", _ctx.foo)')
   })
 
   test('.attr modifier w/ progress value', () => {
     const { code } = compileWithVBind(`<progress :value.attr="foo" />`)
     expect(code).matchSnapshot()
-    expect(code).contains('_setAttr(n0, "value", _ctx.foo, true)')
+    expect(code).contains('_setAttr(n0, "value", _ctx.foo)')
   })
 
   test('attributes must be set as attribute', () => {
@@ -633,11 +631,11 @@ describe('compiler v-bind', () => {
     `)
 
     expect(code).matchSnapshot()
-    expect(code).contains('_setDOMProp(n0, "id", _ctx.id, true)')
-    expect(code).contains('_setDOMProp(n0, "title", _ctx.title, true)')
-    expect(code).contains('_setDOMProp(n0, "lang", _ctx.lang, true)')
-    expect(code).contains('_setDOMProp(n0, "dir", _ctx.dir, true)')
-    expect(code).contains('_setDOMProp(n0, "tabindex", _ctx.tabindex, true)')
+    expect(code).contains('_setDOMProp(n0, "id", _ctx.id)')
+    expect(code).contains('_setDOMProp(n0, "title", _ctx.title)')
+    expect(code).contains('_setDOMProp(n0, "lang", _ctx.lang)')
+    expect(code).contains('_setDOMProp(n0, "dir", _ctx.dir)')
+    expect(code).contains('_setDOMProp(n0, "tabindex", _ctx.tabindex)')
   })
 
   test('SVG global attributes should set as dom prop', () => {
@@ -646,9 +644,9 @@ describe('compiler v-bind', () => {
     `)
 
     expect(code).matchSnapshot()
-    expect(code).contains('_setDOMProp(n0, "id", _ctx.id, true)')
-    expect(code).contains('_setDOMProp(n0, "lang", _ctx.lang, true)')
-    expect(code).contains('_setDOMProp(n0, "tabindex", _ctx.tabindex, true)')
+    expect(code).contains('_setDOMProp(n0, "id", _ctx.id)')
+    expect(code).contains('_setDOMProp(n0, "lang", _ctx.lang)')
+    expect(code).contains('_setDOMProp(n0, "tabindex", _ctx.tabindex)')
   })
 
   test('MathML global attributes should set as dom prop', () => {
@@ -657,13 +655,11 @@ describe('compiler v-bind', () => {
     `)
 
     expect(code).matchSnapshot()
-    expect(code).contains('_setDOMProp(n0, "autofucus", _ctx.autofucus, true)')
-    expect(code).contains('_setDOMProp(n0, "dir", _ctx.dir, true)')
-    expect(code).contains(
-      '_setDOMProp(n0, "displaystyle", _ctx.displaystyle, true)',
-    )
-    expect(code).contains('_setDOMProp(n0, "mathcolor", _ctx.mathcolor, true)')
-    expect(code).contains('_setDOMProp(n0, "tabindex", _ctx.tabindex, true)')
+    expect(code).contains('_setDOMProp(n0, "autofucus", _ctx.autofucus)')
+    expect(code).contains('_setDOMProp(n0, "dir", _ctx.dir)')
+    expect(code).contains('_setDOMProp(n0, "displaystyle", _ctx.displaystyle)')
+    expect(code).contains('_setDOMProp(n0, "mathcolor", _ctx.mathcolor)')
+    expect(code).contains('_setDOMProp(n0, "tabindex", _ctx.tabindex)')
   })
 
   test(':innerHTML', () => {
@@ -671,7 +667,7 @@ describe('compiler v-bind', () => {
       <div :innerHTML="foo"/>
     `)
     expect(code).matchSnapshot()
-    expect(code).contains('_setHtml(n0, _ctx.foo, true)')
+    expect(code).contains('_setHtml(n0, _ctx.foo)')
   })
 
   test(':textContext', () => {
@@ -679,7 +675,7 @@ describe('compiler v-bind', () => {
       <div :textContent="foo"/>
     `)
     expect(code).matchSnapshot()
-    expect(code).contains('_setText(n0, _ctx.foo, true)')
+    expect(code).contains('_setText(n0, _ctx.foo)')
   })
 
   test(':value', () => {
@@ -687,7 +683,7 @@ describe('compiler v-bind', () => {
       <input :value="foo"/>
     `)
     expect(code).matchSnapshot()
-    expect(code).contains('_setValue(n0, _ctx.foo, true)')
+    expect(code).contains('_setValue(n0, _ctx.foo)')
   })
 
   test(':value w/ progress', () => {
@@ -695,7 +691,7 @@ describe('compiler v-bind', () => {
       <progress :value="foo"/>
     `)
     expect(code).matchSnapshot()
-    expect(code).contains('_setDynamicProp(n0, "value", _ctx.foo, true)')
+    expect(code).contains('_setDynamicProp(n0, "value", _ctx.foo)')
   })
 
   test('number value', () => {

--- a/packages/compiler-vapor/__tests__/transforms/vBind.spec.ts
+++ b/packages/compiler-vapor/__tests__/transforms/vBind.spec.ts
@@ -74,7 +74,7 @@ describe('compiler v-bind', () => {
     })
 
     expect(code).matchSnapshot()
-    expect(code).contains('_setAsProp(n0, "id", _ctx.id, true)')
+    expect(code).contains('setDOMProp(n0, "id", _ctx.id, true)')
   })
 
   test('no expression', () => {
@@ -104,7 +104,7 @@ describe('compiler v-bind', () => {
         ],
       },
     })
-    expect(code).contains('_setAsProp(n0, "id", _ctx.id, true)')
+    expect(code).contains('setDOMProp(n0, "id", _ctx.id, true)')
   })
 
   test('no expression (shorthand)', () => {
@@ -561,11 +561,11 @@ describe('compiler v-bind', () => {
     `)
 
     expect(code).matchSnapshot()
-    expect(code).contains('_setAsProp(n0, "id", _ctx.id, true)')
-    expect(code).contains('_setAsProp(n0, "title", _ctx.title, true)')
-    expect(code).contains('_setAsProp(n0, "lang", _ctx.lang, true)')
-    expect(code).contains('_setAsProp(n0, "dir", _ctx.dir, true)')
-    expect(code).contains('_setAsProp(n0, "tabindex", _ctx.tabindex, true)')
+    expect(code).contains('setDOMProp(n0, "id", _ctx.id, true)')
+    expect(code).contains('setDOMProp(n0, "title", _ctx.title, true)')
+    expect(code).contains('setDOMProp(n0, "lang", _ctx.lang, true)')
+    expect(code).contains('setDOMProp(n0, "dir", _ctx.dir, true)')
+    expect(code).contains('setDOMProp(n0, "tabindex", _ctx.tabindex, true)')
   })
 
   test('SVG global attributes should set as dom prop', () => {
@@ -574,9 +574,9 @@ describe('compiler v-bind', () => {
     `)
 
     expect(code).matchSnapshot()
-    expect(code).contains('_setAsProp(n0, "id", _ctx.id, true)')
-    expect(code).contains('_setAsProp(n0, "lang", _ctx.lang, true)')
-    expect(code).contains('_setAsProp(n0, "tabindex", _ctx.tabindex, true)')
+    expect(code).contains('setDOMProp(n0, "id", _ctx.id, true)')
+    expect(code).contains('setDOMProp(n0, "lang", _ctx.lang, true)')
+    expect(code).contains('setDOMProp(n0, "tabindex", _ctx.tabindex, true)')
   })
 
   test('MathML global attributes should set as dom prop', () => {
@@ -585,13 +585,13 @@ describe('compiler v-bind', () => {
     `)
 
     expect(code).matchSnapshot()
-    expect(code).contains('_setAsProp(n0, "autofucus", _ctx.autofucus, true)')
-    expect(code).contains('_setAsProp(n0, "dir", _ctx.dir, true)')
+    expect(code).contains('setDOMProp(n0, "autofucus", _ctx.autofucus, true)')
+    expect(code).contains('setDOMProp(n0, "dir", _ctx.dir, true)')
     expect(code).contains(
-      '_setAsProp(n0, "displaystyle", _ctx.displaystyle, true)',
+      'setDOMProp(n0, "displaystyle", _ctx.displaystyle, true)',
     )
-    expect(code).contains('_setAsProp(n0, "mathcolor", _ctx.mathcolor, true)')
-    expect(code).contains('_setAsProp(n0, "tabindex", _ctx.tabindex, true)')
+    expect(code).contains('setDOMProp(n0, "mathcolor", _ctx.mathcolor, true)')
+    expect(code).contains('setDOMProp(n0, "tabindex", _ctx.tabindex, true)')
   })
 
   test(':innerHTML', () => {

--- a/packages/compiler-vapor/__tests__/transforms/vBind.spec.ts
+++ b/packages/compiler-vapor/__tests__/transforms/vBind.spec.ts
@@ -74,7 +74,7 @@ describe('compiler v-bind', () => {
     })
 
     expect(code).matchSnapshot()
-    expect(code).contains('setDOMProp(n0, "id", _ctx.id, true)')
+    expect(code).contains('_setDOMProp(n0, "id", _ctx.id, true)')
   })
 
   test('no expression', () => {
@@ -104,7 +104,7 @@ describe('compiler v-bind', () => {
         ],
       },
     })
-    expect(code).contains('setDOMProp(n0, "id", _ctx.id, true)')
+    expect(code).contains('_setDOMProp(n0, "id", _ctx.id, true)')
   })
 
   test('no expression (shorthand)', () => {
@@ -561,11 +561,11 @@ describe('compiler v-bind', () => {
     `)
 
     expect(code).matchSnapshot()
-    expect(code).contains('setDOMProp(n0, "id", _ctx.id, true)')
-    expect(code).contains('setDOMProp(n0, "title", _ctx.title, true)')
-    expect(code).contains('setDOMProp(n0, "lang", _ctx.lang, true)')
-    expect(code).contains('setDOMProp(n0, "dir", _ctx.dir, true)')
-    expect(code).contains('setDOMProp(n0, "tabindex", _ctx.tabindex, true)')
+    expect(code).contains('_setDOMProp(n0, "id", _ctx.id, true)')
+    expect(code).contains('_setDOMProp(n0, "title", _ctx.title, true)')
+    expect(code).contains('_setDOMProp(n0, "lang", _ctx.lang, true)')
+    expect(code).contains('_setDOMProp(n0, "dir", _ctx.dir, true)')
+    expect(code).contains('_setDOMProp(n0, "tabindex", _ctx.tabindex, true)')
   })
 
   test('SVG global attributes should set as dom prop', () => {
@@ -574,9 +574,9 @@ describe('compiler v-bind', () => {
     `)
 
     expect(code).matchSnapshot()
-    expect(code).contains('setDOMProp(n0, "id", _ctx.id, true)')
-    expect(code).contains('setDOMProp(n0, "lang", _ctx.lang, true)')
-    expect(code).contains('setDOMProp(n0, "tabindex", _ctx.tabindex, true)')
+    expect(code).contains('_setDOMProp(n0, "id", _ctx.id, true)')
+    expect(code).contains('_setDOMProp(n0, "lang", _ctx.lang, true)')
+    expect(code).contains('_setDOMProp(n0, "tabindex", _ctx.tabindex, true)')
   })
 
   test('MathML global attributes should set as dom prop', () => {
@@ -585,13 +585,13 @@ describe('compiler v-bind', () => {
     `)
 
     expect(code).matchSnapshot()
-    expect(code).contains('setDOMProp(n0, "autofucus", _ctx.autofucus, true)')
-    expect(code).contains('setDOMProp(n0, "dir", _ctx.dir, true)')
+    expect(code).contains('_setDOMProp(n0, "autofucus", _ctx.autofucus, true)')
+    expect(code).contains('_setDOMProp(n0, "dir", _ctx.dir, true)')
     expect(code).contains(
-      'setDOMProp(n0, "displaystyle", _ctx.displaystyle, true)',
+      '_setDOMProp(n0, "displaystyle", _ctx.displaystyle, true)',
     )
-    expect(code).contains('setDOMProp(n0, "mathcolor", _ctx.mathcolor, true)')
-    expect(code).contains('setDOMProp(n0, "tabindex", _ctx.tabindex, true)')
+    expect(code).contains('_setDOMProp(n0, "mathcolor", _ctx.mathcolor, true)')
+    expect(code).contains('_setDOMProp(n0, "tabindex", _ctx.tabindex, true)')
   })
 
   test(':innerHTML', () => {

--- a/packages/compiler-vapor/__tests__/transforms/vBind.spec.ts
+++ b/packages/compiler-vapor/__tests__/transforms/vBind.spec.ts
@@ -454,7 +454,7 @@ describe('compiler v-bind', () => {
     expect(code).contains('_setDOMProp(n0, "fooBar", _ctx.id, true)')
   })
 
-  test('.prop modifier (shortband) w/ no expression', () => {
+  test('.prop modifier (shorthand) w/ no expression', () => {
     const { ir, code } = compileWithVBind(`<div .fooBar />`)
 
     expect(code).matchSnapshot()
@@ -476,6 +476,54 @@ describe('compiler v-bind', () => {
     })
     expect(code).contains('renderEffect')
     expect(code).contains('_setDOMProp(n0, "fooBar", _ctx.fooBar, true)')
+  })
+
+  test('.prop modifier w/ innerHTML', () => {
+    const { code } = compileWithVBind(`<div :innerHTML.prop="foo" />`)
+    expect(code).matchSnapshot()
+    expect(code).contains('_setHtml(n0, _ctx.foo, true)')
+  })
+
+  test('.prop modifier (shorthand) w/ innerHTML', () => {
+    const { code } = compileWithVBind(`<div .innerHTML="foo" />`)
+    expect(code).matchSnapshot()
+    expect(code).contains('_setHtml(n0, _ctx.foo, true)')
+  })
+
+  test('.prop modifier w/ textContent', () => {
+    const { code } = compileWithVBind(`<div :textContent.prop="foo" />`)
+    expect(code).matchSnapshot()
+    expect(code).contains('_setText(n0, _ctx.foo, true)')
+  })
+
+  test('.prop modifier (shorthand) w/ textContent', () => {
+    const { code } = compileWithVBind(`<div .textContent="foo" />`)
+    expect(code).matchSnapshot()
+    expect(code).contains('_setText(n0, _ctx.foo, true)')
+  })
+
+  test('.prop modifier w/ value', () => {
+    const { code } = compileWithVBind(`<div :value.prop="foo" />`)
+    expect(code).matchSnapshot()
+    expect(code).contains('_setValue(n0, _ctx.foo, true)')
+  })
+
+  test('.prop modifier (shorthand) w/ value', () => {
+    const { code } = compileWithVBind(`<div .value="foo" />`)
+    expect(code).matchSnapshot()
+    expect(code).contains('_setValue(n0, _ctx.foo, true)')
+  })
+
+  test('.prop modifier w/ progress value', () => {
+    const { code } = compileWithVBind(`<progress :value.prop="foo" />`)
+    expect(code).matchSnapshot()
+    expect(code).contains('_setDOMProp(n0, "value", _ctx.foo, true)')
+  })
+
+  test('.prop modifier (shorthand) w/ progress value', () => {
+    const { code } = compileWithVBind(`<progress .value="foo" />`)
+    expect(code).matchSnapshot()
+    expect(code).contains('_setDOMProp(n0, "value", _ctx.foo, true)')
   })
 
   test('.attr modifier', () => {
@@ -526,6 +574,54 @@ describe('compiler v-bind', () => {
     expect(code).contains('renderEffect')
     expect(code).contains('_setAttr(n0, "foo-bar", _ctx.fooBar, true)')
   })
+
+  test('.attr modifier w/ innerHTML', () => {
+    const { code } = compileWithVBind(`<div :innerHTML.attr="foo" />`)
+    expect(code).matchSnapshot()
+    expect(code).contains('_setAttr(n0, "innerHTML", _ctx.foo, true)')
+  })
+
+  // test('.attr modifier (shorthand) w/ innerHTML', () => {
+  //   const { code } = compileWithVBind(`<div ^innerHTML="foo" />`)
+  //   expect(code).matchSnapshot()
+  //   expect(code).contains('_setAttr(n0, "innerHTML", _ctx.foo, true)')
+  // })
+
+  test('.attr modifier w/ textContent', () => {
+    const { code } = compileWithVBind(`<div :textContent.attr="foo" />`)
+    expect(code).matchSnapshot()
+    expect(code).contains('_setAttr(n0, "textContent", _ctx.foo, true)')
+  })
+  //
+  // test('.attr modifier (shorthand) w/ textContent', () => {
+  //   const { code } = compileWithVBind(`<div ^textContent="foo" />`)
+  //   expect(code).matchSnapshot()
+  //   expect(code).contains('_setAttr(n0, "textContent", _ctx.foo, true)')
+  // })
+
+  test('.attr modifier w/ value', () => {
+    const { code } = compileWithVBind(`<div :value.attr="foo" />`)
+    expect(code).matchSnapshot()
+    expect(code).contains('_setAttr(n0, "value", _ctx.foo, true)')
+  })
+  //
+  // test('.attr modifier (shorthand) w/ value', () => {
+  //   const { code } = compileWithVBind(`<div ^value="foo" />`)
+  //   expect(code).matchSnapshot()
+  //   expect(code).contains('_setAttr(n0, "value", _ctx.foo, true)')
+  // })
+
+  test('.attr modifier w/ progress value', () => {
+    const { code } = compileWithVBind(`<progress :value.attr="foo" />`)
+    expect(code).matchSnapshot()
+    expect(code).contains('_setAttr(n0, "value", _ctx.foo, true)')
+  })
+  //
+  // test('.attr modifier (shorthand) w/ progress value', () => {
+  //   const { code } = compileWithVBind(`<progress ^value="foo" />`)
+  //   expect(code).matchSnapshot()
+  //   expect(code).contains('_setAttr(n0, "value", _ctx.foo, true)')
+  // })
 
   test('attributes must be set as attribute', () => {
     const { code } = compileWithVBind(`

--- a/packages/compiler-vapor/__tests__/transforms/vBind.spec.ts
+++ b/packages/compiler-vapor/__tests__/transforms/vBind.spec.ts
@@ -74,7 +74,7 @@ describe('compiler v-bind', () => {
     })
 
     expect(code).matchSnapshot()
-    expect(code).contains('_setDOMProp(n0, "id", _ctx.id, true)')
+    expect(code).contains('_setAsProp(n0, "id", _ctx.id, true)')
   })
 
   test('no expression', () => {
@@ -104,7 +104,7 @@ describe('compiler v-bind', () => {
         ],
       },
     })
-    expect(code).contains('_setDOMProp(n0, "id", _ctx.id, true)')
+    expect(code).contains('_setAsProp(n0, "id", _ctx.id, true)')
   })
 
   test('no expression (shorthand)', () => {
@@ -561,11 +561,11 @@ describe('compiler v-bind', () => {
     `)
 
     expect(code).matchSnapshot()
-    expect(code).contains('_setDOMProp(n0, "id", _ctx.id, true)')
-    expect(code).contains('_setDOMProp(n0, "title", _ctx.title, true)')
-    expect(code).contains('_setDOMProp(n0, "lang", _ctx.lang, true)')
-    expect(code).contains('_setDOMProp(n0, "dir", _ctx.dir, true)')
-    expect(code).contains('_setDOMProp(n0, "tabindex", _ctx.tabindex, true)')
+    expect(code).contains('_setAsProp(n0, "id", _ctx.id, true)')
+    expect(code).contains('_setAsProp(n0, "title", _ctx.title, true)')
+    expect(code).contains('_setAsProp(n0, "lang", _ctx.lang, true)')
+    expect(code).contains('_setAsProp(n0, "dir", _ctx.dir, true)')
+    expect(code).contains('_setAsProp(n0, "tabindex", _ctx.tabindex, true)')
   })
 
   test('SVG global attributes should set as dom prop', () => {
@@ -574,9 +574,9 @@ describe('compiler v-bind', () => {
     `)
 
     expect(code).matchSnapshot()
-    expect(code).contains('_setDOMProp(n0, "id", _ctx.id, true)')
-    expect(code).contains('_setDOMProp(n0, "lang", _ctx.lang, true)')
-    expect(code).contains('_setDOMProp(n0, "tabindex", _ctx.tabindex, true)')
+    expect(code).contains('_setAsProp(n0, "id", _ctx.id, true)')
+    expect(code).contains('_setAsProp(n0, "lang", _ctx.lang, true)')
+    expect(code).contains('_setAsProp(n0, "tabindex", _ctx.tabindex, true)')
   })
 
   test('MathML global attributes should set as dom prop', () => {
@@ -585,13 +585,45 @@ describe('compiler v-bind', () => {
     `)
 
     expect(code).matchSnapshot()
-    expect(code).contains('_setDOMProp(n0, "autofucus", _ctx.autofucus, true)')
-    expect(code).contains('_setDOMProp(n0, "dir", _ctx.dir, true)')
+    expect(code).contains('_setAsProp(n0, "autofucus", _ctx.autofucus, true)')
+    expect(code).contains('_setAsProp(n0, "dir", _ctx.dir, true)')
     expect(code).contains(
-      '_setDOMProp(n0, "displaystyle", _ctx.displaystyle, true)',
+      '_setAsProp(n0, "displaystyle", _ctx.displaystyle, true)',
     )
-    expect(code).contains('_setDOMProp(n0, "mathcolor", _ctx.mathcolor, true)')
-    expect(code).contains('_setDOMProp(n0, "tabindex", _ctx.tabindex, true)')
+    expect(code).contains('_setAsProp(n0, "mathcolor", _ctx.mathcolor, true)')
+    expect(code).contains('_setAsProp(n0, "tabindex", _ctx.tabindex, true)')
+  })
+
+  test(':innerHTML', () => {
+    const { code } = compileWithVBind(`
+      <div :innerHTML="foo"/>
+    `)
+    expect(code).matchSnapshot()
+    expect(code).contains('_setHtml(n0, _ctx.foo, true)')
+  })
+
+  test(':textContext', () => {
+    const { code } = compileWithVBind(`
+      <div :textContent="foo"/>
+    `)
+    expect(code).matchSnapshot()
+    expect(code).contains('_setText(n0, _ctx.foo, true)')
+  })
+
+  test(':value', () => {
+    const { code } = compileWithVBind(`
+      <input :value="foo"/>
+    `)
+    expect(code).matchSnapshot()
+    expect(code).contains('_setValue(n0, _ctx.foo, true)')
+  })
+
+  test(':value w/ progress', () => {
+    const { code } = compileWithVBind(`
+      <progress :value="foo"/>
+    `)
+    expect(code).matchSnapshot()
+    expect(code).contains('_setDynamicProp(n0, "value", _ctx.foo, true)')
   })
 
   test('number value', () => {

--- a/packages/compiler-vapor/__tests__/transforms/vBind.spec.ts
+++ b/packages/compiler-vapor/__tests__/transforms/vBind.spec.ts
@@ -581,47 +581,23 @@ describe('compiler v-bind', () => {
     expect(code).contains('_setAttr(n0, "innerHTML", _ctx.foo, true)')
   })
 
-  // test('.attr modifier (shorthand) w/ innerHTML', () => {
-  //   const { code } = compileWithVBind(`<div ^innerHTML="foo" />`)
-  //   expect(code).matchSnapshot()
-  //   expect(code).contains('_setAttr(n0, "innerHTML", _ctx.foo, true)')
-  // })
-
   test('.attr modifier w/ textContent', () => {
     const { code } = compileWithVBind(`<div :textContent.attr="foo" />`)
     expect(code).matchSnapshot()
     expect(code).contains('_setAttr(n0, "textContent", _ctx.foo, true)')
   })
-  //
-  // test('.attr modifier (shorthand) w/ textContent', () => {
-  //   const { code } = compileWithVBind(`<div ^textContent="foo" />`)
-  //   expect(code).matchSnapshot()
-  //   expect(code).contains('_setAttr(n0, "textContent", _ctx.foo, true)')
-  // })
 
   test('.attr modifier w/ value', () => {
     const { code } = compileWithVBind(`<div :value.attr="foo" />`)
     expect(code).matchSnapshot()
     expect(code).contains('_setAttr(n0, "value", _ctx.foo, true)')
   })
-  //
-  // test('.attr modifier (shorthand) w/ value', () => {
-  //   const { code } = compileWithVBind(`<div ^value="foo" />`)
-  //   expect(code).matchSnapshot()
-  //   expect(code).contains('_setAttr(n0, "value", _ctx.foo, true)')
-  // })
 
   test('.attr modifier w/ progress value', () => {
     const { code } = compileWithVBind(`<progress :value.attr="foo" />`)
     expect(code).matchSnapshot()
     expect(code).contains('_setAttr(n0, "value", _ctx.foo, true)')
   })
-  //
-  // test('.attr modifier (shorthand) w/ progress value', () => {
-  //   const { code } = compileWithVBind(`<progress ^value="foo" />`)
-  //   expect(code).matchSnapshot()
-  //   expect(code).contains('_setAttr(n0, "value", _ctx.foo, true)')
-  // })
 
   test('attributes must be set as attribute', () => {
     const { code } = compileWithVBind(`

--- a/packages/compiler-vapor/src/generators/prop.ts
+++ b/packages/compiler-vapor/src/generators/prop.ts
@@ -85,7 +85,7 @@ export function genSetProp(
     (isSVGTag(tag) && isSvgGlobalAttr(keyName)) ||
     (isMathMLTag(tag) && isMathMLGlobalAttr(keyName))
   ) {
-    helperName = 'setAsDOMProp'
+    helperName = 'setDOMProp'
   } else {
     helperName = 'setDynamicProp'
   }

--- a/packages/compiler-vapor/src/generators/prop.ts
+++ b/packages/compiler-vapor/src/generators/prop.ts
@@ -53,7 +53,10 @@ export function genSetProp(
       `n${oper.element}`,
       omitKey ? false : genExpression(key, context),
       genPropValue(values, context),
-      oper.root && 'true',
+      // only `setClass` and `setStyle` need merge inherit attr
+      oper.root && (helperName === 'setClass' || helperName === 'setStyle')
+        ? 'true'
+        : undefined,
     ),
   ]
 }

--- a/packages/compiler-vapor/src/generators/prop.ts
+++ b/packages/compiler-vapor/src/generators/prop.ts
@@ -23,6 +23,7 @@ import {
 } from './utils'
 import {
   attributeCache,
+  canSetValueDirectly,
   isHTMLGlobalAttr,
   isHTMLTag,
   isMathMLGlobalAttr,
@@ -225,7 +226,7 @@ const getSpecialHelper = (
   tagName: string,
 ): { name: VaporHelper; omitKey: boolean } | null => {
   // special case for 'value' property
-  if (keyName === 'value' && tagName !== 'PROGRESS' && !tagName.includes('-')) {
+  if (keyName === 'value' && canSetValueDirectly(tagName)) {
     return { name: 'setValue', omitKey: true }
   }
 

--- a/packages/compiler-vapor/src/generators/prop.ts
+++ b/packages/compiler-vapor/src/generators/prop.ts
@@ -67,12 +67,25 @@ export function genSetProp(
       : attributeCache[attrCacheKey]
   ) {
     helperName = 'setAttr'
+  } else if (keyName === 'innerHTML') {
+    helperName = 'setHtml'
+    omitKey = true
+  } else if (keyName === 'textContent') {
+    helperName = 'setText'
+    omitKey = true
+  } else if (
+    keyName === 'value' &&
+    tagName !== 'PROGRESS' &&
+    !tagName.includes('-')
+  ) {
+    helperName = 'setValue'
+    omitKey = true
   } else if (
     (isHTMLTag(tag) && isHTMLGlobalAttr(keyName)) ||
     (isSVGTag(tag) && isSvgGlobalAttr(keyName)) ||
     (isMathMLTag(tag) && isMathMLGlobalAttr(keyName))
   ) {
-    helperName = 'setDOMProp'
+    helperName = 'setAsDOMProp'
   } else {
     helperName = 'setDynamicProp'
   }

--- a/packages/runtime-vapor/__tests__/dom/prop.spec.ts
+++ b/packages/runtime-vapor/__tests__/dom/prop.spec.ts
@@ -7,6 +7,7 @@ import {
   setDynamicProps,
   setHtml,
   setText,
+  setValue,
 } from '../../src/dom/prop'
 import { setStyle } from '../../src/dom/style'
 import {
@@ -15,6 +16,7 @@ import {
 } from '../../src/component'
 import { getMetadata, recordPropMetadata } from '../../src/componentMetadata'
 import { getCurrentScope } from '@vue/reactivity'
+import { describe } from 'vitest'
 
 let removeComponentInstance = NOOP
 beforeEach(() => {
@@ -239,43 +241,32 @@ describe('patchProp', () => {
     })
   })
 
-  describe('setDOMProp', () => {
-    test('should set DOM property', () => {
-      const el = document.createElement('div')
-      setDOMProp(el, 'textContent', null)
-      expect(el.textContent).toBe('')
-      setDOMProp(el, 'textContent', 'foo')
-      expect(el.textContent).toBe('foo')
-
-      setDOMProp(el, 'innerHTML', null)
-      expect(el.innerHTML).toBe('')
-      setDOMProp(el, 'innerHTML', '<p>bar</p>')
-      expect(el.innerHTML).toBe('<p>bar</p>')
-    })
-
+  describe('setValue', () => {
     test('should set value prop', () => {
       const el = document.createElement('input')
-      setDOMProp(el, 'value', 'foo')
+      setValue(el, 'foo')
       expect(el.value).toBe('foo')
-      setDOMProp(el, 'value', null)
+      setValue(el, null)
       expect(el.value).toBe('')
       expect(el.getAttribute('value')).toBe(null)
       const obj = {}
-      setDOMProp(el, 'value', obj)
+      setValue(el, obj)
       expect(el.value).toBe(obj.toString())
       expect((el as any)._value).toBe(obj)
 
       const option = document.createElement('option')
-      setDOMProp(option, 'textContent', 'foo')
+      setText(option, 'foo')
       expect(option.value).toBe('foo')
       expect(option.getAttribute('value')).toBe(null)
 
-      setDOMProp(option, 'value', 'bar')
+      setValue(option, 'bar')
       expect(option.textContent).toBe('foo')
       expect(option.value).toBe('bar')
       expect(option.getAttribute('value')).toBe('bar')
     })
+  })
 
+  describe('setDOMProp', () => {
     test('should be boolean prop', () => {
       const el = document.createElement('select')
       setDOMProp(el, 'multiple', '')
@@ -455,6 +446,8 @@ describe('patchProp', () => {
   describe('setText', () => {
     test('should set textContent', () => {
       const el = document.createElement('div')
+      setText(el, null)
+      expect(el.textContent).toBe('')
       setText(el, 'foo')
       expect(el.textContent).toBe('foo')
       setText(el, 'bar')
@@ -465,6 +458,8 @@ describe('patchProp', () => {
   describe('setHtml', () => {
     test('should set innerHTML', () => {
       const el = document.createElement('div')
+      setHtml(el, null)
+      expect(el.innerHTML).toBe('')
       setHtml(el, '<p>foo</p>')
       expect(el.innerHTML).toBe('<p>foo</p>')
       setHtml(el, '<p>bar</p>')

--- a/packages/runtime-vapor/__tests__/dom/prop.spec.ts
+++ b/packages/runtime-vapor/__tests__/dom/prop.spec.ts
@@ -16,7 +16,6 @@ import {
 } from '../../src/component'
 import { getMetadata, recordPropMetadata } from '../../src/componentMetadata'
 import { getCurrentScope } from '@vue/reactivity'
-import { describe } from 'vitest'
 
 let removeComponentInstance = NOOP
 beforeEach(() => {

--- a/packages/runtime-vapor/src/dom/prop.ts
+++ b/packages/runtime-vapor/src/dom/prop.ts
@@ -106,7 +106,6 @@ export function setDOMProp(el: any, key: string, value: any): void {
     }
   }
   needRemove && el.removeAttribute(key)
-  return value
 }
 
 export function setDynamicProp(el: Element, key: string, value: any): void {

--- a/packages/runtime-vapor/src/dom/prop.ts
+++ b/packages/runtime-vapor/src/dom/prop.ts
@@ -69,7 +69,7 @@ export function setValue(el: any, value: any): void {
   }
 }
 
-export function setAsDOMProp(el: any, key: string, value: any): void {
+export function setDOMProp(el: any, key: string, value: any): void {
   const oldVal = recordPropMetadata(el, key, value)
   if (value === oldVal) return
 
@@ -109,31 +109,6 @@ export function setAsDOMProp(el: any, key: string, value: any): void {
   return value
 }
 
-export function setDOMProp(el: any, key: string, value: any): void {
-  if (key === 'innerHTML') {
-    setHtml(el, value)
-    return
-  }
-
-  if (key === 'textContent') {
-    setText(el, value)
-    return
-  }
-
-  const tag = el.tagName
-  if (
-    key === 'value' &&
-    tag !== 'PROGRESS' &&
-    // custom elements may use _value internally
-    !tag.includes('-')
-  ) {
-    setValue(el, value)
-    return
-  }
-
-  setAsDOMProp(el, key, value)
-}
-
 export function setDynamicProp(el: Element, key: string, value: any): void {
   // TODO
   const isSVG = false
@@ -150,6 +125,27 @@ export function setDynamicProp(el: Element, key: string, value: any): void {
         ? ((key = key.slice(1)), false)
         : shouldSetAsProp(el, key, value, isSVG)
   ) {
+    if (key === 'innerHTML') {
+      setHtml(el, value)
+      return
+    }
+
+    if (key === 'textContent') {
+      setText(el, value)
+      return
+    }
+
+    const tag = el.tagName
+    if (
+      key === 'value' &&
+      tag !== 'PROGRESS' &&
+      // custom elements may use _value internally
+      !tag.includes('-')
+    ) {
+      setValue(el, value)
+      return
+    }
+
     setDOMProp(el, key, value)
   } else {
     // TODO special case for <input v-model type="checkbox">

--- a/packages/runtime-vapor/src/dom/prop.ts
+++ b/packages/runtime-vapor/src/dom/prop.ts
@@ -1,5 +1,6 @@
 import {
   attributeCache,
+  canSetValueDirectly,
   includeBooleanAttr,
   isArray,
   isFunction,
@@ -135,12 +136,7 @@ export function setDynamicProp(el: Element, key: string, value: any): void {
     }
 
     const tag = el.tagName
-    if (
-      key === 'value' &&
-      tag !== 'PROGRESS' &&
-      // custom elements may use _value internally
-      !tag.includes('-')
-    ) {
+    if (key === 'value' && canSetValueDirectly(tag)) {
       setValue(el, value)
       return
     }

--- a/packages/runtime-vapor/src/index.ts
+++ b/packages/runtime-vapor/src/index.ts
@@ -115,7 +115,6 @@ export {
   setAttr,
   setValue,
   setDOMProp,
-  setAsDOMProp,
   setDynamicProp,
   setDynamicProps,
 } from './dom/prop'

--- a/packages/runtime-vapor/src/index.ts
+++ b/packages/runtime-vapor/src/index.ts
@@ -113,7 +113,9 @@ export {
   setHtml,
   setClass,
   setAttr,
+  setValue,
   setDOMProp,
+  setAsDOMProp,
   setDynamicProp,
   setDynamicProps,
 } from './dom/prop'

--- a/packages/shared/src/general.ts
+++ b/packages/shared/src/general.ts
@@ -227,3 +227,11 @@ export function genCacheKey(source: string, options: any): string {
     )
   )
 }
+
+export function canSetValueDirectly(tagName: string): boolean {
+  return (
+    tagName !== 'PROGRESS' &&
+    // custom elements may use _value internally
+    !tagName.includes('-')
+  )
+}


### PR DESCRIPTION
compile changes:
- If the attribute is `innerHTML`, use `setHtml` directly.
- If the attribute is `textContent`, use `setText` directly.
- If the attribute is `value` and the element is not `progress` or `custom-element`, use `setValue` directly.

runtime changes:
- Simplify the internal logic of `setDOMProp`.
- Add the `setValue` method.