### PR TITLE
perf(runtime-vapor): `setup()` returning object is only needed in __DEV__ (HMR)

### DIFF
--- a/packages/runtime-vapor/src/apiRender.ts
+++ b/packages/runtime-vapor/src/apiRender.ts
@@ -77,10 +77,10 @@ export function setupComponent(instance: ComponentInternalInstance): void {
           VaporErrorCodes.RENDER_FUNCTION,
           [
             instance.setupState, // _ctx
-            __DEV__ ? shallowReadonly(props) : props, // $props
+            shallowReadonly(props), // $props
             instance.emit, // $emit
-            __DEV__ ? getAttrsProxy(instance) : instance.attrs, // $attrs
-            __DEV__ ? getSlotsProxy(instance) : instance.slots, // $slots
+            getAttrsProxy(instance), // $attrs
+            getSlotsProxy(instance), // $slots
           ],
         )
         resetTracking()

--- a/packages/runtime-vapor/src/apiRender.ts
+++ b/packages/runtime-vapor/src/apiRender.ts
@@ -55,32 +55,38 @@ export function setupComponent(instance: ComponentInternalInstance): void {
 
     let block: Block | undefined
 
-    if (
-      stateOrNode &&
-      (stateOrNode instanceof Node ||
-        isArray(stateOrNode) ||
-        fragmentKey in stateOrNode ||
-        componentKey in stateOrNode)
-    ) {
+    // Skip the type check for production since this is only for Dev HMR
+    if (__DEV__) {
+      if (
+        stateOrNode &&
+        (stateOrNode instanceof Node ||
+          isArray(stateOrNode) ||
+          fragmentKey in stateOrNode ||
+          componentKey in stateOrNode)
+      ) {
+        block = stateOrNode
+      } else if (isObject(stateOrNode)) {
+        instance.setupState = proxyRefs(stateOrNode)
+      }
+
+      if (!block && component.render) {
+        pauseTracking()
+        block = callWithErrorHandling(
+          component.render,
+          instance,
+          VaporErrorCodes.RENDER_FUNCTION,
+          [
+            instance.setupState, // _ctx
+            __DEV__ ? shallowReadonly(props) : props, // $props
+            instance.emit, // $emit
+            __DEV__ ? getAttrsProxy(instance) : instance.attrs, // $attrs
+            __DEV__ ? getSlotsProxy(instance) : instance.slots, // $slots
+          ],
+        )
+        resetTracking()
+      }
+    } else {
       block = stateOrNode
-    } else if (isObject(stateOrNode)) {
-      instance.setupState = proxyRefs(stateOrNode)
-    }
-    if (!block && component.render) {
-      pauseTracking()
-      block = callWithErrorHandling(
-        component.render,
-        instance,
-        VaporErrorCodes.RENDER_FUNCTION,
-        [
-          instance.setupState, // _ctx
-          __DEV__ ? shallowReadonly(props) : props, // $props
-          instance.emit, // $emit
-          __DEV__ ? getAttrsProxy(instance) : instance.attrs, // $attrs
-          __DEV__ ? getSlotsProxy(instance) : instance.slots, // $slots
-        ],
-      )
-      resetTracking()
     }
 
     if (!block) {


### PR DESCRIPTION
Skip [the type check](https://github.com/vuejs/vue-vapor/blob/e61cedf3fdac8770540198bca077ae3ae1bf5cbd/packages/runtime-vapor/src/apiRender.ts#L58-L64) for production since this is only for Dev HMR