### PR TITLE
[WIP] fix: handle v-for to singleRoot

### DIFF
--- a/packages/compiler-vapor/__tests__/transforms/transformElement.spec.ts
+++ b/packages/compiler-vapor/__tests__/transforms/transformElement.spec.ts
@@ -6,6 +6,7 @@ import {
   transformElement,
   transformText,
   transformVBind,
+  transformVFor,
   transformVOn,
 } from '../../src'
 import {
@@ -15,7 +16,12 @@ import {
 } from '@vue/compiler-core'
 
 const compileWithElementTransform = makeCompile({
-  nodeTransforms: [transformElement, transformChildren, transformText],
+  nodeTransforms: [
+    transformVFor,
+    transformElement,
+    transformChildren,
+    transformText,
+  ],
   directiveTransforms: {
     bind: transformVBind,
     on: transformVOn,
@@ -183,6 +189,16 @@ describe('compiler: element transform', () => {
       })
       expect(code).toMatchSnapshot()
       expect(code).contains('_createComponent(_ctx.Comp, null, null, true)')
+    })
+
+    test('generate root component with v-for', () => {
+      const { code } = compileWithElementTransform(
+        `<Comp v-for="i in 1000"/>`,
+        {
+          bindingMetadata: { Comp: BindingTypes.SETUP_CONST },
+        },
+      )
+      expect(code).contains('_createComponent(_ctx.Comp)')
     })
 
     test('generate multi root component', () => {

--- a/packages/compiler-vapor/src/transforms/transformElement.ts
+++ b/packages/compiler-vapor/src/transforms/transformElement.ts
@@ -75,6 +75,7 @@ export const transformElement: NodeTransform = (node, context) => {
     }
     const singleRoot =
       context.root === parent &&
+      !parent.ir.source.includes('v-for') &&
       parent.node.children.filter(child => child.type !== NodeTypes.COMMENT)
         .length === 1
 


### PR DESCRIPTION
This PR is **work in progress**.

# Overview

This PR is related to #299.

As my [comment](https://github.com/vuejs/vue-vapor/issues/299#issuecomment-2625292299):
>I've noticed that if there is only a single root element, the fourth argument is included.
However, if there are multiple elements, just simply add a single `<div />`, there is only one argument which aligns with our expectations.

I then tried adding a condition to check whether the root component has a single root and whether it includes `v-for`.

The test case I added passed, but some existing test cases failed due to snapshot differences.

# Need Help and Suggestions
I would appreciate any suggestions or guidance on how to solve this issue.
Especially, I’d like to know the best way to determine if a node is the root and is associated with `v-for`, so I can refine my condition.

If my approach is not ideal or does not align with your expectations, please let me know, and I will update my code accordingly.




